### PR TITLE
Update instance type for windows builders to c4

### DIFF
--- a/configs/b-2008
+++ b/configs/b-2008
@@ -16,7 +16,7 @@
         "security_group_ids": [
             "sg-e758e982"
         ],
-        "instance_type": "c3.2xlarge",
+        "instance_type": "c4.2xlarge",
         "distro": "win2008",
         "ssh_key": "aws-releng",
         "use_public_ip": true,
@@ -47,7 +47,7 @@
         "security_group_ids": [
             "sg-f5ca0690"
         ],
-        "instance_type": "c3.2xlarge",
+        "instance_type": "c4.2xlarge",
         "distro": "win2008",
         "ssh_key": "aws-releng",
         "use_public_ip": true,

--- a/configs/watch_pending.cfg
+++ b/configs/watch_pending.cfg
@@ -62,13 +62,13 @@
     "spot": {
         "rules": {
             "b-2008": [
-                {"instance_type": "c3.2xlarge",
+                {"instance_type": "c4.2xlarge",
                  "ignored_azs": ["us-east-1b", "us-east-1e"],
                  "performance_constant": 1,
                  "bid_price": 0.53}
             ],
             "y-2008": [
-                {"instance_type": "c3.2xlarge",
+                {"instance_type": "c4.2xlarge",
                  "ignored_azs": ["us-east-1b", "us-east-1e"],
                  "performance_constant": 1,
                  "bid_price": 0.53}

--- a/configs/y-2008
+++ b/configs/y-2008
@@ -15,7 +15,7 @@
         "security_group_ids": [
             "sg-718b1214"
         ],
-        "instance_type": "c3.2xlarge",
+        "instance_type": "c4.2xlarge",
         "distro": "win2008",
         "ssh_key": "aws-releng",
         "use_public_ip": true,
@@ -46,7 +46,7 @@
         "security_group_ids": [
             "sg-3aaa095f"
         ],
-        "instance_type": "c3.2xlarge",
+        "instance_type": "c4.2xlarge",
         "distro": "win2008",
         "ssh_key": "aws-releng",
         "use_public_ip": true,


### PR DESCRIPTION
Updated builder instance type  to c4 for cost savings and to help congestion 