### PR TITLE
Bug 1315061 - bump c4.2xlarge big to $1.30/hr

### DIFF
--- a/configs/watch_pending.cfg
+++ b/configs/watch_pending.cfg
@@ -67,13 +67,13 @@
                 {"instance_type": "c4.2xlarge",
                  "ignored_azs": ["us-east-1b", "us-east-1e"],
                  "performance_constant": 1,
-                 "bid_price": 1.0}
+                 "bid_price": 1.5}
             ],
             "y-2008": [
                 {"instance_type": "c4.2xlarge",
                  "ignored_azs": ["us-east-1b", "us-east-1e"],
                  "performance_constant": 1,
-                 "bid_price": 1.0}
+                 "bid_price": 1.5}
             ],
             "t-w732": [
                 {"instance_type": "c3.2xlarge",


### PR DESCRIPTION
This will result in spot requests when the current price is $1, since bid * 0.8 will be great than 1.0.