### PR TITLE
Fix flake8 complaints

### DIFF
--- a/cloudtools/graphite.py
+++ b/cloudtools/graphite.py
@@ -59,6 +59,7 @@ class GraphiteLogger(object):
                 log.warn("Ignoring all grapite submissions!")
         self._data = {}
 
+
 _graphite_logger = GraphiteLogger()
 
 

--- a/cloudtools/scripts/aws_check_subnets.py
+++ b/cloudtools/scripts/aws_check_subnets.py
@@ -125,5 +125,6 @@ def main():
     exit_code = report_free_ips(grouped_subnets, args.warn_threshold, args.crit_threshold)
     exit(exit_code)
 
+
 if __name__ == '__main__':
     main()

--- a/cloudtools/scripts/aws_clean_log_dir.py
+++ b/cloudtools/scripts/aws_clean_log_dir.py
@@ -128,5 +128,6 @@ def main():
                 instance_event_file = os.path.join(root, f)
                 delete_obsolete_json_file(instance_event_file, numdays)
 
+
 if __name__ == '__main__':
     main()

--- a/cloudtools/scripts/aws_create_ami.py
+++ b/cloudtools/scripts/aws_create_ami.py
@@ -513,5 +513,6 @@ def main():
         new_ami = copy_ami(ami, r)
         log.info("New AMI created. AMI ID: %s", new_ami.id)
 
+
 if __name__ == '__main__':
     main()

--- a/cloudtools/scripts/aws_create_instance.py
+++ b/cloudtools/scripts/aws_create_instance.py
@@ -315,5 +315,6 @@ def main():
         new_ami = copy_ami(ami, r)
         log.info("New AMI created. AMI ID: %s", new_ami.id)
 
+
 if __name__ == '__main__':
     main()

--- a/cloudtools/scripts/aws_create_win_ami.py
+++ b/cloudtools/scripts/aws_create_win_ami.py
@@ -119,5 +119,6 @@ def main():
                                     args['--key-name'])
     create_ami(host_instance, args['--config'], config)
 
+
 if __name__ == '__main__':
     main()

--- a/cloudtools/scripts/aws_deploy_stack.py
+++ b/cloudtools/scripts/aws_deploy_stack.py
@@ -237,5 +237,6 @@ def main():
     if not success:
         sys.exit(1)
 
+
 if __name__ == '__main__':
     main()

--- a/cloudtools/scripts/aws_get_cloudtrail_logs.py
+++ b/cloudtools/scripts/aws_get_cloudtrail_logs.py
@@ -109,5 +109,6 @@ def main():
         pool.close()
         pool.join()
 
+
 if __name__ == '__main__':
     main()

--- a/cloudtools/scripts/aws_manage_instances.py
+++ b/cloudtools/scripts/aws_manage_instances.py
@@ -156,5 +156,6 @@ def main():
                 elif args.action == "status":
                     status(i)
 
+
 if __name__ == '__main__':
     main()

--- a/cloudtools/scripts/aws_manage_routingtables.py
+++ b/cloudtools/scripts/aws_manage_routingtables.py
@@ -143,5 +143,6 @@ def main():
 
         sync_tables(conn, my_tables, remote_tables)
 
+
 if __name__ == '__main__':
     main()

--- a/cloudtools/scripts/aws_process_cloudtrail_logs.py
+++ b/cloudtools/scripts/aws_process_cloudtrail_logs.py
@@ -128,5 +128,6 @@ def main():
     pool.close()
     pool.join()
 
+
 if __name__ == '__main__':
     main()

--- a/cloudtools/scripts/aws_publish_amis.py
+++ b/cloudtools/scripts/aws_publish_amis.py
@@ -72,5 +72,6 @@ def main():
                                           filters={"state": "available"}))
     update_ami_status(amis_to_dict(images))
 
+
 if __name__ == '__main__':
     main()

--- a/cloudtools/scripts/aws_sanity_checker.py
+++ b/cloudtools/scripts/aws_sanity_checker.py
@@ -271,5 +271,6 @@ def main():
                     volumes=all_volumes,
                     events_dir=args.events_dir)
 
+
 if __name__ == '__main__':
     main()

--- a/cloudtools/scripts/aws_stop_idle.py
+++ b/cloudtools/scripts/aws_stop_idle.py
@@ -292,5 +292,6 @@ def main():
     gr_log.sendall()
     log.debug("done")
 
+
 if __name__ == '__main__':
     main()

--- a/cloudtools/scripts/aws_terminate_by_ami_id.py
+++ b/cloudtools/scripts/aws_terminate_by_ami_id.py
@@ -63,5 +63,6 @@ def main():
             i.terminate()
             log.warn("Done.")
 
+
 if __name__ == '__main__':
     main()

--- a/cloudtools/scripts/aws_watch_pending.py
+++ b/cloudtools/scripts/aws_watch_pending.py
@@ -589,5 +589,6 @@ def main():
     gr_log.sendall()
     log.debug("done")
 
+
 if __name__ == '__main__':
     main()

--- a/cloudtools/scripts/copy_ami.py
+++ b/cloudtools/scripts/copy_ami.py
@@ -28,5 +28,6 @@ def main():
             new_ami = copy_ami(ami, r)
             log.info("New AMI created. AMI ID: %s", new_ami.id)
 
+
 if __name__ == '__main__':
     main()

--- a/cloudtools/scripts/ec22ip.py
+++ b/cloudtools/scripts/ec22ip.py
@@ -28,5 +28,6 @@ def main():
                 if mask.search(hostname) and i.private_ip_address:
                     print i.private_ip_address, hostname
 
+
 if __name__ == '__main__':
     main()

--- a/cloudtools/scripts/free_ips.py
+++ b/cloudtools/scripts/free_ips.py
@@ -41,5 +41,6 @@ def main():
     for ip in sample:
         print ip
 
+
 if __name__ == "__main__":
     main()

--- a/cloudtools/scripts/get_spot_amis.py
+++ b/cloudtools/scripts/get_spot_amis.py
@@ -31,5 +31,6 @@ def main():
                                            ami.tags.get("Name"),
                                            ami.root_device_type)
 
+
 if __name__ == '__main__':
     main()

--- a/cloudtools/scripts/spot_sanity_check.py
+++ b/cloudtools/scripts/spot_sanity_check.py
@@ -58,5 +58,6 @@ def main():
     regions = args.regions or DEFAULT_REGIONS
     sanity_check(regions)
 
+
 if __name__ == '__main__':
     main()

--- a/cloudtools/scripts/tag_spot_instances.py
+++ b/cloudtools/scripts/tag_spot_instances.py
@@ -40,5 +40,6 @@ def main():
                 log.debug("tagging %s", i)
                 copy_spot_request_tags(i)
 
+
 if __name__ == '__main__':
     main()

--- a/configs/cloudformation/network.py
+++ b/configs/cloudformation/network.py
@@ -81,6 +81,7 @@ def resolve_host(hostname):
 
 # VPC
 
+
 cft = CloudFormationTemplate(description="Release Engineering network configuration")
 
 cft.resources.add(Resource(


### PR DESCRIPTION
flake8 v3.2.0 complains when you don't have two empty lines after class and function definitions, eg
```
py27 runtests: commands[0] | flake8
./cloudtools/graphite.py:62:1: E305 expected 2 blank lines after class or function definition, found 1
_graphite_logger = GraphiteLogger()
^

./cloudtools/scripts/aws_check_subnets.py:128:1: E305 expected 2 blank lines after class or function definition, found 1
if __name__ == '__main__':
^
```
Change log is at http://flake8.pycqa.org/en/latest/release-notes/3.2.0.html