### PR TITLE
Add linux and windows builders for l10n repack and update verify

### DIFF
--- a/configs/watch_pending.cfg
+++ b/configs/watch_pending.cfg
@@ -6,6 +6,10 @@
     },
     "buildermap": {
         ".*_antivirus$": "av-linux64",
+        "^release-.*_firefox_win(32|64)_l10n_repack": "b-2008",
+        "^release-.*_firefox_linux(64)?_l10n_repack": "bld-linux64",
+        "^release-.*_win(32|64)_update_verify": "b-2008",
+        "^release-.*_linux(64)?_update_verify": "bld-linux64",
         "Android.* (?!try|Tegra|Panda|Emulator|debug)\\S+ (?:debug )?(build|non-unified)": "bld-linux64",
         "Android.* (?!Tegra|Panda|Emulator)try (?:debug )?build": "try-linux64",
         "^(TB )?Linux (Code Coverage |Mulet )?(?!try)\\S+ (pgo-|leak test |Code Coverage |Mulet )?(spidermonkey.* )?build": "bld-linux64",


### PR DESCRIPTION
Because we have many releases in flight and need to make sure instances spin up for buildbot-based jobs.