### PR TITLE
Bug 1331636 Remove old installation of HG

### DIFF
--- a/configs/b-2008
+++ b/configs/b-2008
@@ -3,7 +3,7 @@
     "us-east-1": {
         "type": "b-2008",
         "domain": "build.releng.use1.mozilla.com",
-        "ami": "ami-2903e244",
+        "ami": "ami-69b25a7f",
         "subnet_ids": [
             "subnet-2ba98340",
             "subnet-2da98346",
@@ -49,7 +49,7 @@
     "us-west-2": {
         "type": "b-2008",
         "domain": "build.releng.usw2.mozilla.com",
-        "ami": "ami-654fbc05",
+        "ami": "ami-c0308ca0",
         "subnet_ids": [
             "subnet-d748dabe",
             "subnet-a848dac1",

--- a/configs/y-2008
+++ b/configs/y-2008
@@ -3,7 +3,7 @@
     "us-east-1": {
         "type": "y-2008",
         "domain": "try.releng.use1.mozilla.com",
-        "ami": "ami-f43edf99",
+        "ami": "ami-3cb0582a",
         "subnet_ids": [
             "subnet-27a9834c",
             "subnet-39a98352",
@@ -48,7 +48,7 @@
     "us-west-2": {
         "type": "y-2008",
         "domain": "try.releng.usw2.mozilla.com",
-        "ami": "ami-e047b480",
+        "ami": "ami-52338f32",
         "subnet_ids": [
             "subnet-ae48dac7",
             "subnet-a348daca",


### PR DESCRIPTION
The old installation of HG was causing intermittent timeouts of the install of the new version of HG. 