### PR TITLE
Bug 1357837: add shipit cnames to terraform

### DIFF
--- a/terraform/base/route53.tf
+++ b/terraform/base/route53.tf
@@ -18,7 +18,15 @@ variable "heroku_cnames" {
                "tooltool",
                "tooltool.staging",
                "treestatus",
-               "treestatus.staging"]
+               "treestatus.staging",
+               "pipeline.shipit",
+               "pipeline.shipit.staging",
+               "signoff.shipit",
+               "signoff.shipit.staging",
+               "taskcluster.shipit",
+               "taskcluster.shipit.staging",
+               "uplift.shipit",
+               "uplift.shipit.staging"]
 }
 
 # CNAME records for heroku apps


### PR DESCRIPTION
This simply adds in the shipit cnames for the new shipit heroku apps.  It has already been applied via terraform.  This just needs to be merged to match reality.