### PR TITLE
Bug 1362594 - Disable indexing of all volumes

### DIFF
--- a/configs/Ec2UserdataUtils.psm1
+++ b/configs/Ec2UserdataUtils.psm1
@@ -674,6 +674,11 @@ function Disable-Firewall {
   Disable-Service -serviceName 'WinDefend'
 }
 
+# Disables indexing on all disk volumes (for performance).
+function Disable-Indexing {
+  Get-WmiObject Win32_Volume -Filter "IndexingEnabled=$true" | Set-WmiInstance -Arguments @{IndexingEnabled=$false}
+}
+
 function Flush-EventLog {
   <#
   .Synopsis

--- a/configs/b-2008.user-data
+++ b/configs/b-2008.user-data
@@ -105,7 +105,8 @@ Import-Module Ec2UserdataUtils
 New-Item -ItemType Directory -Force -Path $logDir
 Set-Ec2ConfigPluginsState
 Set-Timezone
-Disable-Firewall 
+Disable-Firewall
+Disable-Indexing
 Disable-WindowsUpdate
 Install-BasePrerequisites -aggregator $aggregator -domain $domain
 Rename-Admin


### PR DESCRIPTION
Windows enables disk indexing on all volumes by default. If the indexing
service is running, this will incur overhead as I/O occurs. If the
indexing service isn't running, it shouldn't matter what the setting
is.

It feels prudent to disable indexing on volumes just to be sure.