### PR TITLE
 Bug 1362356 - Replace Install-RelOpsPrerequisites function

### DIFF
--- a/configs/Ec2UserdataUtils.psm1
+++ b/configs/Ec2UserdataUtils.psm1
@@ -514,7 +514,7 @@ function Is-HostnameSetCorrectly {
     [string] $hostnameExpected
   )
   $netDnsHostname = [System.Net.Dns]::GetHostName()
-  if (("$hostnameExpected" -ieq "$netDnsHostname") -and ("$hostnameExpected" -ieq "$env:COMPUTERNAME")) {
+  if (("$hostnameExpected" -ieq "$netDnsHostname") -and (("$hostnameExpected" -ieq "$env:COMPUTERNAME") -or (('{0}EN' -f $env:COMPUTERNAME) -ieq $hostnameExpected))) {
     return $true
   } else {
     Write-Log -message ('net dns hostname: {0}, expected: {1}' -f $netDnsHostname, $hostnameExpected) -severity 'DEBUG'

--- a/configs/Ec2UserdataUtils.psm1
+++ b/configs/Ec2UserdataUtils.psm1
@@ -1672,6 +1672,22 @@ function Install-BasePrerequisites {
   # end hacks
 }
 
+function Install-RelOpsPrerequisites {
+  param (
+    [string] $aggregator
+  )
+  Configure-NxLog -aggregator $aggregator
+  #https://bugzilla.mozilla.org/show_bug.cgi?id=1261812
+  if (-not (Get-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\' -Name 'LocalDumps' -ErrorAction SilentlyContinue)) {
+    New-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\' -Name 'LocalDumps'
+  }
+  if (-not (Get-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\' -Name 'DontShowUI' -ErrorAction SilentlyContinue)) {
+    New-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\' -Type 'DWord' -Name 'DontShowUI' -Value '0x00000001'
+  } else {
+    Set-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\' -Type 'DWord' -Name 'DontShowUI' -Value '0x00000001'
+  }
+}
+
 function Set-Timezone {
   param (
     [string] $timezone = 'Pacific Standard Time'

--- a/configs/Ec2UserdataUtils.psm1
+++ b/configs/Ec2UserdataUtils.psm1
@@ -514,7 +514,7 @@ function Is-HostnameSetCorrectly {
     [string] $hostnameExpected
   )
   $netDnsHostname = [System.Net.Dns]::GetHostName()
-  if (("$hostnameExpected" -ieq "$netDnsHostname") -and (("$hostnameExpected" -ieq "$env:COMPUTERNAME")) {
+  if (("$hostnameExpected" -ieq "$netDnsHostname") -and ("$hostnameExpected" -ieq "$env:COMPUTERNAME")) {
     return $true
   } else {
     Write-Log -message ('net dns hostname: {0}, expected: {1}' -f $netDnsHostname, $hostnameExpected) -severity 'DEBUG'

--- a/configs/Ec2UserdataUtils.psm1
+++ b/configs/Ec2UserdataUtils.psm1
@@ -514,7 +514,7 @@ function Is-HostnameSetCorrectly {
     [string] $hostnameExpected
   )
   $netDnsHostname = [System.Net.Dns]::GetHostName()
-  if (("$hostnameExpected" -ieq "$netDnsHostname") -and (("$hostnameExpected" -ieq "$env:COMPUTERNAME") -or (('{0}EN' -f $env:COMPUTERNAME) -ieq $hostnameExpected))) {
+  if (("$hostnameExpected" -ieq "$netDnsHostname") -and (("$hostnameExpected" -ieq "$env:COMPUTERNAME")) {
     return $true
   } else {
     Write-Log -message ('net dns hostname: {0}, expected: {1}' -f $netDnsHostname, $hostnameExpected) -severity 'DEBUG'

--- a/configs/Ec2UserdataUtils.psm1
+++ b/configs/Ec2UserdataUtils.psm1
@@ -1655,7 +1655,6 @@ function Install-BasePrerequisites {
     [string] $domain = 'releng.use1.mozilla.com'
   )
   Install-RelOpsPrerequisites -aggregator $aggregator
-  Enable-CloneBundle
   #Install-MozillaBuildAndPrerequisites
   #Install-BuildBot
   #Install-ToolTool


### PR DESCRIPTION
Portions of the function needed to be replaced. 

<arr> nthomas: which pref setting?
<@nthomas> there’s a call to Configure-NxLog -aggregator $aggregator, in https://github.com/mozilla-releng/build-cloud-tools/commit/f029f17a73e0f3a6fa2d00fb54cc2b5a95dfc504

 

<markco> i will added back on the next pr
<arr> nor should the error reporting stuff, I think
<arr> unless those are being installed elsewhere
<@nthomas> thanks mark
<arr> sublimetext3 should have been deleted
<arr> I think everything else in there probably should have stayed