### PR TITLE
bug 1359389 - securitygroups remove influxdb

### DIFF
--- a/configs/securitygroups.yml
+++ b/configs/securitygroups.yml
@@ -119,12 +119,6 @@ includes:
         hosts:
             - 0.0.0.0/0
 
-    outbound-influx:
-        proto: tcp
-        ports: [8087]
-        hosts:
-            - goldiewilson-onepointtwentyone-1.c.influxdb.com
-
     outbound-irc:
         proto: tcp
         ports: [6697]
@@ -164,7 +158,6 @@ includes:
         - include: outbound-stun-tcp
         - include: outbound-stun-udp
         - include: outbound-carbon
-        - include: outbound-influx
         - include: outbound-ntp
         - include: global-ping
 
@@ -177,7 +170,6 @@ includes:
         - include: outbound-stun-tcp
         - include: outbound-stun-udp
         - include: outbound-carbon
-        - include: outbound-influx
         - include: outbound-ntp
         - include: global-ping
 
@@ -190,7 +182,6 @@ includes:
         - include: outbound-stun-tcp
         - include: outbound-stun-udp
         - include: outbound-carbon
-        - include: outbound-influx
         - include: outbound-ntp
         - include: global-ping
 


### PR DESCRIPTION
@AlinSelagea is this the modification needed for the security policies for https://bugzilla.mozilla.org/show_bug.cgi?id=1359389 ? It sounds like we've removed influxdb entirely, and so I removed the definition and uses.