### PR TITLE
bug 1379653 - create depsigning workers

### DIFF
--- a/configs/depsigning-worker
+++ b/configs/depsigning-worker
@@ -1,0 +1,48 @@
+{
+    "us-east-1": {
+        "type": "depsigning-worker",
+        "domain": "srv.releng.use1.mozilla.com",
+        "ami": "ami-58246f30",
+        "subnet_ids": ["subnet-957710cc"],
+        "security_group_ids": ["sg-cf1027ab"],
+        "instance_type": "t2.micro",
+        "distro": "centos",
+        "ssh_key": "aws-releng",
+        "use_public_ip": true,
+        "instance_profile_name": "depsigning-worker",
+        "device_map": {
+            "/dev/xvda": {
+                "delete_on_termination": true,
+                "skip_resize": true,
+                "volume_type": "gp2",
+                "instance_dev": "/dev/xvda1"
+            }
+        },
+        "tags": {
+            "moz-type": "depsigning-worker"
+        }
+    },
+    "us-west-2": {
+        "type": "depsigning-worker",
+        "domain": "srv.releng.usw2.mozilla.com",
+        "ami": "ami-eb89acdb",
+        "subnet_ids": ["subnet-d50cb6a2"],
+        "security_group_ids": ["sg-ff8b939a"],
+        "instance_type": "t2.micro",
+        "distro": "centos",
+        "ssh_key": "aws-releng",
+        "use_public_ip": true,
+        "instance_profile_name": "depsigning-worker",
+        "device_map": {
+            "/dev/xvda": {
+                "delete_on_termination": true,
+                "skip_resize": true,
+                "volume_type": "gp2",
+                "instance_dev": "/dev/xvda1"
+            }
+        },
+        "tags": {
+            "moz-type": "depsigning-worker"
+        }
+    }
+}

--- a/configs/depsigning-worker.user-data
+++ b/configs/depsigning-worker.user-data
@@ -1,0 +1,14 @@
+#cloud-config
+
+fqdn: {fqdn}
+hostname: {fqdn}
+package_update: false
+resize_rootfs: true
+manage_etc_hosts: true
+disable_root: false
+ssh_pwauth: true
+moz_instance_type: {moz_instance_type}
+mounts: false
+rsyslog:
+ - filename: log_aggregator_client.conf
+   content: "*.* @@log-aggregator.srv.releng.{region_dns_atom}.mozilla.com:1514"


### PR DESCRIPTION
depsigning [script]workers can spin up without any special config. Let's automate that via cloud tools!

I'm still holding off on standard signing scriptworkers because they require gpg keypairs in hiera... not sure if that's a great reason.