### PR TITLE
Bug 1166064 - fix creation of new security groups

### DIFF
--- a/cloudtools/scripts/aws_manage_securitygroups.py
+++ b/cloudtools/scripts/aws_manage_securitygroups.py
@@ -266,11 +266,12 @@ def main():
                     vpc_id=sg_config['regions'][region],
                     description=sg_config['description'],
                 )
+                log.info("New group has id %s", remote_sg.id)
                 log.info("Waiting for group to propagate")
                 time.sleep(5)
                 # Fetch it again so we get all the rules
                 log.info("Re-loading group %s", sg_name)
-                remote_sg = conn.get_all_security_groups(
+                remote_sg = conns_by_region[region].get_all_security_groups(
                     group_ids=[remote_sg.id])[0]
 
             sync_security_group(remote_sg, sg_config, prompt=prompt)


### PR DESCRIPTION
`conn` is a connection to one of the regions in the config (see line 232 of this file) and may not match the region where we created a new sec group. Explicitly using the connection for the same region avoids the failure to look up the group (due to longer propagation delays than we allow for).

Also logs the id of the new sec group to avoid having to go to the console to find it.