### PR TITLE
mozilla-releng.net route53 resources generated from ...

### DIFF
--- a/terraform/base/route53.tf
+++ b/terraform/base/route53.tf
@@ -1,220 +1,15 @@
-# Route 53 resources
 
-# Hosted Zone for mozilla-releng.net
+######################################################################
+#                                                                    #
+# IMPORTANT: mozilla-releng.net resources were generated, do not     #
+#            change them manually!                                   #
+#                                                                    #
+#     https://docs.mozilla-releng.net/deploy/configure-dns.html      #
+#                                                                    #
+######################################################################
+
 resource "aws_route53_zone" "mozilla-releng" {
     name = "mozilla-releng.net."
-}
-
-##################################
-## Heroku production app cnames ##
-##################################
-
-resource "aws_route53_record" "heroku-coalease-cname" {
-    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
-    name = "coalesce.mozilla-releng.net"
-    type = "CNAME"
-    ttl = "180"
-    records = ["oita-54541.herokussl.com"]
-}
-resource "aws_route53_record" "heroku-archiver-cname-prod" {
-    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
-    name = "archiver.mozilla-releng.net"
-    type = "CNAME"
-    ttl = "180"
-    records = ["archiver.mozilla-releng.net.herokudns.com"]
-}
-resource "aws_route53_record" "heroku-clobberer-cname-prod" {
-    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
-    name = "clobberer.mozilla-releng.net"
-    type = "CNAME"
-    ttl = "180"
-    records = ["saitama-70467.herokussl.com"]
-}
-resource "aws_route53_record" "heroku-mapper-cname-prod" {
-    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
-    name = "mapper.mozilla-releng.net"
-    type = "CNAME"
-    ttl = "180"
-    records = ["mapper.mozilla-releng.net.herokudns.com"]
-}
-resource "aws_route53_record" "heroku-tooltool-cname-prod" {
-    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
-    name = "tooltool.mozilla-releng.net"
-    type = "CNAME"
-    ttl = "180"
-    records = ["kochi-11433.herokussl.com"]
-}
-resource "aws_route53_record" "heroku-treestatus-cname-prod" {
-    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
-    name = "treestatus.mozilla-releng.net"
-    type = "CNAME"
-    ttl = "180"
-    records = ["treestatus.mozilla-releng.net.herokudns.com"]
-}
-
-
-###############################
-## Heroku staging app cnames ##
-###############################
-
-resource "aws_route53_record" "heroku-archiver-cname-stage" {
-    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
-    name = "archiver.staging.mozilla-releng.net"
-    type = "CNAME"
-    ttl = "180"
-    records = ["archiver.staging.mozilla-releng.net.herokudns.com"]
-}
-resource "aws_route53_record" "heroku-clobberer-cname-stage" {
-    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
-    name = "clobberer.staging.mozilla-releng.net"
-    type = "CNAME"
-    ttl = "180"
-    records = ["saitama-70467.herokussl.com"]
-}
-resource "aws_route53_record" "heroku-mapper-cname-stage" {
-    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
-    name = "mapper.staging.mozilla-releng.net"
-    type = "CNAME"
-    ttl = "180"
-    records = ["mapper.staging.mozilla-releng.net.herokudns.com"]
-}
-resource "aws_route53_record" "heroku-treestatus-cname-stage" {
-    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
-    name = "treestatus.staging.mozilla-releng.net"
-    type = "CNAME"
-    ttl = "180"
-    records = ["nagasaki-25852.herokussl.com"]
-}
-resource "aws_route53_record" "heroku-tooltool-cname-stage" {
-    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
-    name = "tooltool.staging.mozilla-releng.net"
-    type = "CNAME"
-    ttl = "180"
-    records = ["shizuoka-60622.herokussl.com"]
-}
-
-
-#########################################
-## Heroku Shipit production app cnames ##
-#########################################
-
-resource "aws_route53_record" "heroku-dashboard-shipit-cname-prod" {
-    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
-    name = "dashboard.shipit.mozilla-releng.net"
-    type = "CNAME"
-    ttl = "180"
-    records = ["dashboard.shipit.mozilla-releng.net.herokudns.com"]
-}
-resource "aws_route53_record" "heroku-pipeline-shipit-cname-prod" {
-    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
-    name = "pipeline.shipit.mozilla-releng.net"
-    type = "CNAME"
-    ttl = "180"
-    records = ["pipeline.shipit.mozilla-releng.net.herokudns.com"]
-}
-resource "aws_route53_record" "heroku-signoff-shipit-cname-prod" {
-    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
-    name = "signoff.shipit.mozilla-releng.net"
-    type = "CNAME"
-    ttl = "180"
-    records = ["signoff.shipit.mozilla-releng.net.herokudns.com"]
-}
-resource "aws_route53_record" "heroku-taskcluster-shipit-cname-prod" {
-    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
-    name = "taskcluster.shipit.mozilla-releng.net"
-    type = "CNAME"
-    ttl = "180"
-    records = ["taskcluster.shipit.mozilla-releng.net.herokudns.com"]
-}
-resource "aws_route53_record" "heroku-uplift-shipit-cname-prod" {
-    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
-    name = "uplift.shipit.mozilla-releng.net"
-    type = "CNAME"
-    ttl = "180"
-    records = ["uplift.shipit.mozilla-releng.net.herokudns.com"]
-}
-
-
-######################################
-## Heroku Shipit staging app cnames ##
-######################################
-
-resource "aws_route53_record" "heroku-dashboard-shipit-cname-stage" {
-    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
-    name = "dashboard.shipit.staging.mozilla-releng.net"
-    type = "CNAME"
-    ttl = "180"
-    records = ["dashboard.shipit.staging.mozilla-releng.net.herokudns.com"]
-}
-resource "aws_route53_record" "heroku-pipeline-shipit-cname-stage" {
-    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
-    name = "pipeline.shipit.staging.mozilla-releng.net"
-    type = "CNAME"
-    ttl = "180"
-    records = ["pipeline.shipit.staging.mozilla-releng.net.herokudns.com"]
-}
-resource "aws_route53_record" "heroku-signoff-shipit-cname-stage" {
-    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
-    name = "signoff.shipit.staging.mozilla-releng.net"
-    type = "CNAME"
-    ttl = "180"
-    records = ["signoff.shipit.staging.mozilla-releng.net.herokudns.com"]
-}
-resource "aws_route53_record" "heroku-taskcluster-shipit-cname-stage" {
-    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
-    name = "taskcluster.shipit.staging.mozilla-releng.net"
-    type = "CNAME"
-    ttl = "180"
-    records = ["taskcluster.shipit.staging.mozilla-releng.net.herokudns.com"]
-}
-resource "aws_route53_record" "heroku-uplift-shipit-cname-stage" {
-    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
-    name = "uplift.shipit.staging.mozilla-releng.net"
-    type = "CNAME"
-    ttl = "180"
-    records = ["uplift.shipit.staging.mozilla-releng.net.herokudns.com"]
-}
-
-############################
-## CloudFront CDN aliases ##
-############################
-
-variable "cloudfront_alias" {
-    default = ["docs",
-               "docs.staging",
-               "shipit",
-               "shiptit.staging",
-               "www",
-               "staging"]
-}
-
-# Cloudfront Alias Targets
-# In the future, these may be sourced directly from terraform cloudfront resources
-# should we decide to manage cloudfronts in terraform
-variable "cloudfront_alias_domain" {
-    type = "map"
-    default = {
-        docs = "d1945er7u4liht"
-        docs.staging = "d32jt14rospqzr"
-        shipit = "dve8yd1431ifz"
-        shiptit.staging = "d2ld4e8bl8yd1l"
-        www = "d1qqwps52z1e12"
-        staging = "dpwmwa9tge2p3"
-    }
-}
-
-# A (Alias) records for cloudfront apps
-resource "aws_route53_record" "cloudfront-alias" {
-    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
-    name = "${element(var.cloudfront_alias, count.index)}.mozilla-releng.net"
-    type = "A"
-    count = "${length(var.cloudfront_alias)}"
-
-    alias {
-        name = "${var.cloudfront_alias_domain[element(var.cloudfront_alias, count.index)]}.cloudfront.net."
-        zone_id = "Z2FDTNDATAQYW2"
-        evaluate_target_health = false
-    }
 }
 
 # A special root alias that points to www.mozilla-releng.net
@@ -228,5 +23,229 @@ resource "aws_route53_record" "root-alias" {
         zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
         evaluate_target_health = false
     }
+}
+
+resource "aws_route53_record" "heroku-coalease-cname" {
+    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
+    name = "coalesce.mozilla-releng.net"
+    type = "CNAME"
+    ttl = "180"
+    records = ["oita-54541.herokussl.com"]
+}
+
+
+resource "aws_route53_record" "heroku-archiver-cname-stage" {
+    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
+    name = "archiver.staging.mozilla-releng.net"
+    type = "CNAME"
+    ttl = "180"
+    records = ["archiver.staging.mozilla-releng.net.herokudns.com"]
+}
+
+
+resource "aws_route53_record" "heroku-clobberer-cname-stage" {
+    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
+    name = "clobberer.staging.mozilla-releng.net"
+    type = "CNAME"
+    ttl = "180"
+    records = ["saitama-70467.herokussl.com"]
+}
+
+
+resource "aws_route53_record" "heroku-docs-cname-prod" {
+    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
+    name = "docs.mozilla-releng.net"
+    type = "A"
+    alias {
+        name = "d1945er7u4liht.cloudfront.net."
+        zone_id = "Z2FDTNDATAQYW2"
+        evaluate_target_health = false
+    }
+}
+
+
+resource "aws_route53_record" "heroku-docs-cname-stage" {
+    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
+    name = "docs.staging.mozilla-releng.net"
+    type = "A"
+    alias {
+        name = "d32jt14rospqzr.cloudfront.net."
+        zone_id = "Z2FDTNDATAQYW2"
+        evaluate_target_health = false
+    }
+}
+
+
+resource "aws_route53_record" "heroku-frontend-cname-prod" {
+    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
+    name = "mozilla-releng.net"
+    type = "A"
+    alias {
+        name = "d1qqwps52z1e12.cloudfront.net."
+        zone_id = "Z2FDTNDATAQYW2"
+        evaluate_target_health = false
+    }
+}
+
+
+resource "aws_route53_record" "heroku-frontend-cname-stage" {
+    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
+    name = "staging.mozilla-releng.net"
+    type = "A"
+    alias {
+        name = "dpwmwa9tge2p3.cloudfront.net."
+        zone_id = "Z2FDTNDATAQYW2"
+        evaluate_target_health = false
+    }
+}
+
+
+resource "aws_route53_record" "heroku-mapper-cname-stage" {
+    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
+    name = "mapper.staging.mozilla-releng.net"
+    type = "CNAME"
+    ttl = "180"
+    records = ["mapper.staging.mozilla-releng.net.herokudns.com"]
+}
+
+
+resource "aws_route53_record" "heroku-notification-identity-cname-prod" {
+    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
+    name = "identity.notification.mozilla-releng.net"
+    type = "CNAME"
+    ttl = "180"
+    records = ["identity.notification..mozilla-releng.net.herokudns.com"]
+}
+
+
+resource "aws_route53_record" "heroku-notification-identity-cname-stage" {
+    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
+    name = "identity.notification.staging.mozilla-releng.net"
+    type = "CNAME"
+    ttl = "180"
+    records = ["identity.notification.staging.mozilla-releng.net.herokudns.com"]
+}
+
+
+resource "aws_route53_record" "heroku-notification-policy-cname-prod" {
+    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
+    name = "policy.notification.mozilla-releng.net"
+    type = "CNAME"
+    ttl = "180"
+    records = ["policy.notification..mozilla-releng.net.herokudns.com"]
+}
+
+
+resource "aws_route53_record" "heroku-notification-policy-cname-stage" {
+    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
+    name = "policy.notification.staging.mozilla-releng.net"
+    type = "CNAME"
+    ttl = "180"
+    records = ["policy.notification.staging.mozilla-releng.net.herokudns.com"]
+}
+
+
+resource "aws_route53_record" "heroku-tooltool-cname-prod" {
+    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
+    name = "tooltool.mozilla-releng.net"
+    type = "CNAME"
+    ttl = "180"
+    records = ["kochi-11433.herokussl.com"]
+}
+
+
+resource "aws_route53_record" "heroku-tooltool-cname-stage" {
+    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
+    name = "tooltool.staging.mozilla-releng.net"
+    type = "CNAME"
+    ttl = "180"
+    records = ["shizuoka-60622.herokussl.com"]
+}
+
+
+resource "aws_route53_record" "heroku-treestatus-cname-prod" {
+    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
+    name = "treestatus.mozilla-releng.net"
+    type = "CNAME"
+    ttl = "180"
+    records = ["kochi-31413.herokussl.com"]
+}
+
+
+resource "aws_route53_record" "heroku-treestatus-cname-stage" {
+    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
+    name = "treestatus.staging.mozilla-releng.net"
+    type = "CNAME"
+    ttl = "180"
+    records = ["treestatus.staging.mozilla-releng.net.herokudns.com"]
+}
+
+
+resource "aws_route53_record" "heroku-frontend-shipit-cname-prod" {
+    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
+    name = "shipit.mozilla-releng.net"
+    type = "A"
+    alias {
+        name = "dve8yd1431ifz.cloudfront.net."
+        zone_id = "Z2FDTNDATAQYW2"
+        evaluate_target_health = false
+    }
+}
+
+
+resource "aws_route53_record" "heroku-frontend-shipit-cname-stage" {
+    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
+    name = "shipit.staging.mozilla-releng.net"
+    type = "A"
+    alias {
+        name = "d2ld4e8bl8yd1l.cloudfront.net."
+        zone_id = "Z2FDTNDATAQYW2"
+        evaluate_target_health = false
+    }
+}
+
+
+resource "aws_route53_record" "heroku-pipeline-shipit-cname-stage" {
+    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
+    name = "pipeline.shipit.staging.mozilla-releng.net"
+    type = "CNAME"
+    ttl = "180"
+    records = ["pipeline.shipit.staging.mozilla-releng.net.herokudns.com"]
+}
+
+
+resource "aws_route53_record" "heroku-signoff-shipit-cname-stage" {
+    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
+    name = "signoff.shipit.staging.mozilla-releng.net"
+    type = "CNAME"
+    ttl = "180"
+    records = ["signoff.shipit.staging.mozilla-releng.net.herokudns.com"]
+}
+
+
+resource "aws_route53_record" "heroku-taskcluster-shipit-cname-stage" {
+    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
+    name = "taskcluster.shipit.staging.mozilla-releng.net"
+    type = "CNAME"
+    ttl = "180"
+    records = ["taskcluster.shipit.staging.mozilla-releng.net.herokudns.com"]
+}
+
+
+resource "aws_route53_record" "heroku-uplift-shipit-cname-prod" {
+    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
+    name = "uplift.shipit.mozilla-releng.net"
+    type = "CNAME"
+    ttl = "180"
+    records = ["uplift.shipit.mozilla-releng.net.herokudns.com"]
+}
+
+
+resource "aws_route53_record" "heroku-uplift-shipit-cname-stage" {
+    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
+    name = "uplift.shipit.staging.mozilla-releng.net"
+    type = "CNAME"
+    ttl = "180"
+    records = ["uplift.shipit.staging.mozilla-releng.net.herokudns.com"]
 }
 


### PR DESCRIPTION
configuration in mozilla-releng/services

  $ ./please tools terraform-route53-config

Problem we are trying to solve/avoid is that with growing number of
services it is hard to keep track what is deployed to production and/or
staging.

For this reason we added new subcomand to ./please command that
generates route53 configuration, since what is deployed where is already
stored aloside with with code.

@dividehex Please take this PR as a preview that I'm going into the right direction. We still need to configure correctly some values, but I'm going to ping you in [different PR](https://github.com/mozilla-releng/services/pull/574) and later update this PR.