### PR TITLE
Bug 1361930 - support for NAT gateways, swing traffic for staging uploads that way

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,6 @@ install:
     - travis_retry pip install tox==1.8
 script:
     - tox -e py27
-    - for f in `find . -name '*.json'` ./configs/watch_pending.cfg; do echo $f; done
+    - for f in `find * -name '*.json'` ./configs/watch_pending.cfg; do python -m json.tool $f; done
 after_success:
     - tox -e py27-coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,6 @@ install:
     - travis_retry pip install tox==1.8
 script:
     - tox -e py27
-    - for f in `find . -name '*.json'` ./configs/watch_pending.cfg; do python -m json.tool $f; done
+    - for f in `find . -name '*.json'` ./configs/watch_pending.cfg; do echo $f; done
 after_success:
     - tox -e py27-coveralls

--- a/configs/routingtables.yml
+++ b/configs/routingtables.yml
@@ -22,9 +22,9 @@ us-west-2:
             upload.ffxbld.productdelivery.prod.mozaws.net: IGW
             upload.trybld.productdelivery.prod.mozaws.net: IGW
             upload.tbirdbld.productdelivery.prod.mozaws.net: IGW
-            upload.ffxbld.productdelivery.stage.mozaws.net: IGW
-            upload.trybld.productdelivery.stage.mozaws.net: IGW
-            upload.tbirdbld.productdelivery.stage.mozaws.net: IGW
+            upload.ffxbld.productdelivery.stage.mozaws.net: NAT
+            upload.trybld.productdelivery.stage.mozaws.net: NAT
+            upload.tbirdbld.productdelivery.stage.mozaws.net: NAT
             # seabld only here to appease firewall-test complexity, no harm
             upload.seabld.productdelivery.prod.mozaws.net: IGW
             upload.seabld.productdelivery.stage.mozaws.net: IGW
@@ -63,8 +63,8 @@ us-west-2:
             upload.ffxbld.productdelivery.prod.mozaws.net: IGW
             upload.tbirdbld.productdelivery.prod.mozaws.net: IGW
             upload.seabld.productdelivery.prod.mozaws.net: IGW
-            upload.ffxbld.productdelivery.stage.mozaws.net: IGW
-            upload.tbirdbld.productdelivery.stage.mozaws.net: IGW
+            upload.ffxbld.productdelivery.stage.mozaws.net: NAT
+            upload.tbirdbld.productdelivery.stage.mozaws.net: NAT
             upload.seabld.productdelivery.stage.mozaws.net: IGW
             crash-stats.mozilla.com: IGW
             queue.taskcluster.net: IGW
@@ -82,7 +82,7 @@ us-west-2:
             aus4.mozilla.org: IGW
             aus5.mozilla.org: IGW
             upload.trybld.productdelivery.prod.mozaws.net: IGW
-            upload.trybld.productdelivery.stage.mozaws.net: IGW
+            upload.trybld.productdelivery.stage.mozaws.net: NAT
             queue.taskcluster.net: IGW
 
             10.132.0.0/16: local
@@ -104,6 +104,12 @@ us-west-2:
             10.132.0.0/16: local
             0.0.0.0/0: VGW
 
+    upload-nat:
+        routes:
+            10.132.0.0/16: local
+            0.0.0.0/0: IGW
+
+
 us-east-1:
     default:
         routes:
@@ -120,9 +126,9 @@ us-east-1:
             upload.ffxbld.productdelivery.prod.mozaws.net: IGW
             upload.trybld.productdelivery.prod.mozaws.net: IGW
             upload.tbirdbld.productdelivery.prod.mozaws.net: IGW
-            upload.ffxbld.productdelivery.stage.mozaws.net: IGW
-            upload.trybld.productdelivery.stage.mozaws.net: IGW
-            upload.tbirdbld.productdelivery.stage.mozaws.net: IGW
+            upload.ffxbld.productdelivery.stage.mozaws.net: NAT
+            upload.trybld.productdelivery.stage.mozaws.net: NAT
+            upload.tbirdbld.productdelivery.stage.mozaws.net: NAT
             # seabld only here to appease firewall-test complexity, no harm
             upload.seabld.productdelivery.prod.mozaws.net: IGW
             upload.seabld.productdelivery.stage.mozaws.net: IGW
@@ -161,8 +167,8 @@ us-east-1:
             upload.ffxbld.productdelivery.prod.mozaws.net: IGW
             upload.tbirdbld.productdelivery.prod.mozaws.net: IGW
             upload.seabld.productdelivery.prod.mozaws.net: IGW
-            upload.ffxbld.productdelivery.stage.mozaws.net: IGW
-            upload.tbirdbld.productdelivery.stage.mozaws.net: IGW
+            upload.ffxbld.productdelivery.stage.mozaws.net: NAT
+            upload.tbirdbld.productdelivery.stage.mozaws.net: NAT
             upload.seabld.productdelivery.stage.mozaws.net: IGW
             crash-stats.mozilla.com: IGW
             queue.taskcluster.net: IGW
@@ -181,7 +187,7 @@ us-east-1:
             aus4.mozilla.org: IGW
             aus5.mozilla.org: IGW
             upload.trybld.productdelivery.prod.mozaws.net: IGW
-            upload.trybld.productdelivery.stage.mozaws.net: IGW
+            upload.trybld.productdelivery.stage.mozaws.net: NAT
             queue.taskcluster.net: IGW
 
             10.134.0.0/16: local
@@ -215,3 +221,8 @@ us-east-1:
 
             10.134.0.0/16: local
             0.0.0.0/0: VGW
+
+    upload-nat:
+        routes:
+            10.134.0.0/16: local
+            0.0.0.0/0: IGW

--- a/configs/subnets.yml
+++ b/configs/subnets.yml
@@ -48,6 +48,10 @@ us-west-2:
             name: signing
             routing_table: signing
 
+        10.132.31.0/24:
+            name: upload-nat
+            routing_table: upload-nat
+
 
 us-east-1:
     vpc-b42100df:
@@ -114,3 +118,7 @@ us-east-1:
         10.134.30.0/24:
             name: signing
             routing_table: signing
+
+        10.134.31.0/24:
+            name: upload-nat
+            routing_table: upload-nat

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,14 @@ setup(
         'cfn-pyplates>=0.5.0',
         'IPy==0.81',
         'redo==1.4',
+        'boto3==1.4.7',
+        'botocore==1.7.7',
+        'docutils==0.14',
+        'futures==3.1.1',
+        'jmespath==0.9.3',
+        'python-dateutil==2.6.0',
+        's3transfer==0.1.11',
+        'six==1.10.0',
     ],
     extras_require={
         'test': [


### PR DESCRIPTION
This is the bulk of the new code
* setting up a new 'public' subnet in each region for the NAT gateway to reside in, and a routing table that sends outbound traffic from the NAT to the IGW
* support to look up the NAT gateway, which we reluctantly do using boto3 because boto doesn't support them
* use the gateway for staging upload hosts for testing porpoises
Setup of the one NAT gateway per region is manual, once the subnets exist and EIPs are allocated.

After this lands is
* almost-production testing that NAT gateway is working for staging hosts
* verify network ACL situation (no external access to NAT, maybe lock down NAT subnet to master + build subnets)

and then
* swing production traffic over to NAT gateway and verify log and build uploads OK
* ask CloudOps to whitelist IPs on prod hosts and block other traffic