### PR TITLE
Security group audit

### DIFF
--- a/configs/securitygroups.yml
+++ b/configs/securitygroups.yml
@@ -391,18 +391,7 @@ puppet-master:
             - 10.132.0.0/16
             - 10.134.0.0/16
 
-        # TODO: REMOVE; ONLY NEEDED FOR DISTINGUSHED MASTERS
-        # SSH from other masters
-        - proto: tcp
-          ports: [22]
-          hosts:
-            - releng-puppet1.srv.releng.scl3.mozilla.com
-            - releng-puppet2.srv.releng.scl3.mozilla.com
-            - releng-puppet1.srv.releng.mdc1.mozilla.com
-            - releng-puppet2.srv.releng.mdc1.mozilla.com
-            # it'd be nice to be able to reference this SG here, instead
-            - releng-puppet1.srv.releng.use1.mozilla.com
-            - releng-puppet1.srv.releng.usw2.mozilla.com
+        # Only distinguished masters need inbound ssh from other masters
 
         # generic stuff
         - include: universal

--- a/configs/securitygroups.yml
+++ b/configs/securitygroups.yml
@@ -15,9 +15,21 @@ includes:
         hosts:
           - 0.0.0.0/0
 
-    # administrative hosts have unrestricted access on all ports
-    admin-access:
-        proto: -1
+    jumphost-admin-access:
+        proto: tcp
+        ports: [22, 3389, 5900]
+        hosts:
+          - rejh1.srv.releng.scl3.mozilla.com  # 10.26.48.19
+          - rejh2.srv.releng.scl3.mozilla.com  # 10.26.48.20
+          - rejh1.srv.releng.mdc1.mozilla.com  # 10.49.48.100
+          - rejh2.srv.releng.mdc1.mozilla.com  # 10.49.48.101
+          # TODO: REMOVE vpn and IT jumphost direct access
+          - 10.22.240.0/20  # scl3-vpn-net
+          - ssh1.corpdmz.scl3.mozilla.com
+
+    it-admin-access:
+        proto: tcp
+        ports: [22, 3389, 5900]
         hosts:
           - 10.22.75.6/31  # admin1a/b
           - admin1.private.scl3.mozilla.com
@@ -25,15 +37,20 @@ includes:
           - openvpn1.stage.corpdmz.scl3.mozilla.com
           - ssh1.corpdmz.scl3.mozilla.com
           - ssh1.stage.corpdmz.scl3.mozilla.com
-          - nagios1.private.releng.scl3.mozilla.com  # note: includes tcp/5666
-          - nagios1.private.releng.mdc1.mozilla.com  # note: includes tcp/5666
-          - vportal1a.ops.scl3.mozilla.com
           - 10.22.240.0/20  # scl3-vpn-net
           - 10.22.20.0/25  # admin1.scl3-vpn
-          - rejh1.srv.releng.scl3.mozilla.com  # 10.26.48.19
-          - rejh2.srv.releng.scl3.mozilla.com  # 10.26.48.20
-          - rejh1.srv.releng.mdc1.mozilla.com  # 10.49.48.100
-          - rejh2.srv.releng.mdc1.mozilla.com  # 10.49.48.101
+
+    nagios-any:
+        proto: -1
+        hosts:
+          - nagios1.private.releng.scl3.mozilla.com  # note: includes tcp/5666
+          - nagios1.private.releng.mdc1.mozilla.com  # note: includes tcp/5666
+
+    universal:
+        - include: aws-manager-ssh
+        - include: jumphost-admin-access
+        - include: nagios-any
+        - include: global-ping
 
     # infra puppetizes hosts by SSHing to them from the master
     infra-puppetize:
@@ -50,7 +67,7 @@ includes:
             - {include: slaveapi-servers}
             - aws-manager1.srv.releng.scl3.mozilla.com
             - aws-manager2.srv.releng.scl3.mozilla.com
-        - include: admin-access
+        - include: jumphost-admin-access
         - include: global-ping
 
     outbound-http-https:
@@ -353,9 +370,7 @@ buildbot-master:
             - buildduty-tools.srv.releng.usw2.mozilla.com
 
         # generic stuff
-        - include: aws-manager-ssh
-        - include: admin-access
-        - include: global-ping
+        - include: universal
     outbound:
         # TODO: bug 1210137
         - include: global-any
@@ -376,6 +391,7 @@ puppet-master:
             - 10.132.0.0/16
             - 10.134.0.0/16
 
+        # TODO: REMOVE; ONLY NEEDED FOR DISTINGUSHED MASTERS
         # SSH from other masters
         - proto: tcp
           ports: [22]
@@ -389,9 +405,7 @@ puppet-master:
             - releng-puppet1.srv.releng.usw2.mozilla.com
 
         # generic stuff
-        - include: aws-manager-ssh
-        - include: admin-access
-        - include: global-ping
+        - include: universal
     outbound:
         # TODO: bug 1210137
         - include: global-any
@@ -406,8 +420,7 @@ blobber:
         - proto: tcp
           ports: [443]
           hosts: {include: slave-vlans}
-        - include: admin-access
-        - include: global-ping
+        - include: universal
     outbound:
         # TODO: bug 1210137
         - include: global-any
@@ -419,9 +432,9 @@ nagios:
         us-west-2: vpc-cd63f2a4
         us-east-1: vpc-b42100df
     inbound:
-        - include: admin-access
+        - include: universal
+        - include: it-admin-access
         - include: infra-puppetize
-        - include: global-ping
     outbound:
         - include: global-any
 
@@ -443,9 +456,7 @@ proxxy-vpc-use1:
             - {include: test5-use1}
             - {include: try-use1}
             - {include: try2-use1}
-        - include: aws-manager-ssh
-        - include: admin-access
-        - include: global-ping
+        - include: universal
     outbound:
         # TODO: bug 1210137
         - include: global-any
@@ -464,9 +475,7 @@ proxxy-vpc-usw2:
             - {include: test3-usw2}
             - {include: test4-usw2}
             - {include: try-usw2}
-        - include: aws-manager-ssh
-        - include: admin-access
-        - include: global-ping
+        - include: universal
     outbound:
         # TODO: bug 1210137
         - include: global-any
@@ -485,9 +494,7 @@ LogAggregators:
             - 10.130.0.0/16
             - 10.132.0.0/16
             - 10.134.0.0/16
-        - include: aws-manager-ssh
-        - include: admin-access
-        - include: global-ping
+        - include: universal
     outbound:
         # TODO: bug 1210137
         - include: global-any
@@ -499,9 +506,7 @@ VCSSync:
         us-west-2: vpc-cd63f2a4
         us-east-1: vpc-b42100df
     inbound:
-        - include: aws-manager-ssh
-        - include: admin-access
-        - include: global-ping
+        - include: universal
     outbound:
         # TODO: bug 1210137
         - include: global-any
@@ -513,14 +518,7 @@ signing-worker:
         us-west-2: vpc-cd63f2a4
         us-east-1: vpc-b42100df
     inbound:
-        - proto: tcp
-          ports:
-            - 22  # ssh
-          hosts:
-          - 10.22.240.0/20  # scl3-vpn-net
-        - include: admin-access
-        - include: global-ping
-        - include: aws-manager-ssh
+        - include: universal
     outbound:
         # TODO: bug 1210137
         - include: global-any
@@ -531,14 +529,7 @@ balrogworker:
         us-east-1: vpc-b42100df
         us-west-2: vpc-cd63f2a4
     inbound:
-        - proto: tcp
-          ports:
-            - 22  # ssh
-          hosts:
-          - 10.22.240.0/20
-        - include: admin-access
-        - include: global-ping
-        - include: aws-manager-ssh
+        - include: universal
     outbound:
         - include: global-any
 
@@ -548,14 +539,7 @@ beetmoverworker:
         us-east-1: vpc-b42100df
         us-west-2: vpc-cd63f2a4
     inbound:
-        - proto: tcp
-          ports:
-            - 22  # ssh
-          hosts:
-          - 10.22.240.0/20
-        - include: admin-access
-        - include: global-ping
-        - include: aws-manager-ssh
+        - include: universal
     outbound:
         - include: global-any
 
@@ -564,14 +548,7 @@ pushapkworker:
     regions:
         us-east-1: vpc-b42100df
     inbound:
-        - proto: tcp
-          ports:
-            - 22  # ssh
-          hosts:
-            - 10.22.240.0/20
-        - include: admin-access
-        - include: global-ping
-        - include: aws-manager-ssh
+        - include: universal
     outbound:
         - include: global-any
 
@@ -581,13 +558,6 @@ binarytransparencyworker:
         us-east-1: vpc-b42100df
         us-west-2: vpc-cd63f2a4
     inbound:
-        - proto: tcp
-          ports:
-            - 22  # ssh
-          hosts:
-          - 10.22.240.0/20
-        - include: admin-access
-        - include: global-ping
-        - include: aws-manager-ssh
+        - include: universal
     outbound:
         - include: global-any

--- a/configs/securitygroups.yml
+++ b/configs/securitygroups.yml
@@ -35,13 +35,6 @@ includes:
           - rejh1.srv.releng.mdc1.mozilla.com  # 10.49.48.100
           - rejh2.srv.releng.mdc1.mozilla.com  # 10.49.48.101
 
-    # observium has universal SNMP access
-    observium:
-        proto: udp
-        ports: [161]
-        hosts:
-          - observium2.private.scl3.mozilla.com
-
     # infra puppetizes hosts by SSHing to them from the master
     infra-puppetize:
         proto: tcp
@@ -58,7 +51,6 @@ includes:
             - aws-manager1.srv.releng.scl3.mozilla.com
             - aws-manager2.srv.releng.scl3.mozilla.com
         - include: admin-access
-        - include: observium
         - include: global-ping
 
     outbound-http-https:
@@ -363,7 +355,6 @@ buildbot-master:
         # generic stuff
         - include: aws-manager-ssh
         - include: admin-access
-        - include: observium
         - include: global-ping
     outbound:
         # TODO: bug 1210137
@@ -400,7 +391,6 @@ puppet-master:
         # generic stuff
         - include: aws-manager-ssh
         - include: admin-access
-        - include: observium
         - include: global-ping
     outbound:
         # TODO: bug 1210137
@@ -417,7 +407,6 @@ blobber:
           ports: [443]
           hosts: {include: slave-vlans}
         - include: admin-access
-        - include: observium
         - include: global-ping
     outbound:
         # TODO: bug 1210137
@@ -431,7 +420,6 @@ nagios:
         us-east-1: vpc-b42100df
     inbound:
         - include: admin-access
-        - include: observium
         - include: infra-puppetize
         - include: global-ping
     outbound:
@@ -457,7 +445,6 @@ proxxy-vpc-use1:
             - {include: try2-use1}
         - include: aws-manager-ssh
         - include: admin-access
-        - include: observium
         - include: global-ping
     outbound:
         # TODO: bug 1210137
@@ -479,7 +466,6 @@ proxxy-vpc-usw2:
             - {include: try-usw2}
         - include: aws-manager-ssh
         - include: admin-access
-        - include: observium
         - include: global-ping
     outbound:
         # TODO: bug 1210137
@@ -501,7 +487,6 @@ LogAggregators:
             - 10.134.0.0/16
         - include: aws-manager-ssh
         - include: admin-access
-        - include: observium
         - include: global-ping
     outbound:
         # TODO: bug 1210137
@@ -516,7 +501,6 @@ VCSSync:
     inbound:
         - include: aws-manager-ssh
         - include: admin-access
-        - include: observium
         - include: global-ping
     outbound:
         # TODO: bug 1210137
@@ -535,7 +519,6 @@ signing-worker:
           hosts:
           - 10.22.240.0/20  # scl3-vpn-net
         - include: admin-access
-        - include: observium
         - include: global-ping
         - include: aws-manager-ssh
     outbound:
@@ -554,7 +537,6 @@ balrogworker:
           hosts:
           - 10.22.240.0/20
         - include: admin-access
-        - include: observium
         - include: global-ping
         - include: aws-manager-ssh
     outbound:
@@ -572,7 +554,6 @@ beetmoverworker:
           hosts:
           - 10.22.240.0/20
         - include: admin-access
-        - include: observium
         - include: global-ping
         - include: aws-manager-ssh
     outbound:
@@ -589,7 +570,6 @@ pushapkworker:
           hosts:
             - 10.22.240.0/20
         - include: admin-access
-        - include: observium
         - include: global-ping
         - include: aws-manager-ssh
     outbound:
@@ -607,7 +587,6 @@ binarytransparencyworker:
           hosts:
           - 10.22.240.0/20
         - include: admin-access
-        - include: observium
         - include: global-ping
         - include: aws-manager-ssh
     outbound:

--- a/configs/securitygroups.yml
+++ b/configs/securitygroups.yml
@@ -27,19 +27,6 @@ includes:
           - 10.22.240.0/20  # scl3-vpn-net
           - ssh1.corpdmz.scl3.mozilla.com
 
-    it-admin-access:
-        proto: tcp
-        ports: [22, 3389, 5900]
-        hosts:
-          - 10.22.75.6/31  # admin1a/b
-          - admin1.private.scl3.mozilla.com
-          - openvpn1.corpdmz.scl3.mozilla.com
-          - openvpn1.stage.corpdmz.scl3.mozilla.com
-          - ssh1.corpdmz.scl3.mozilla.com
-          - ssh1.stage.corpdmz.scl3.mozilla.com
-          - 10.22.240.0/20  # scl3-vpn-net
-          - 10.22.20.0/25  # admin1.scl3-vpn
-
     nagios-nrpe:
         proto: tcp
         ports: [5666]
@@ -52,13 +39,6 @@ includes:
         - include: jumphost-admin-access
         - include: nagios-nrpe
         - include: global-ping
-
-    # infra puppetizes hosts by SSHing to them from the master
-    infra-puppetize:
-        proto: tcp
-        ports: [22]
-        hosts:
-          - puppet1.private.scl3.mozilla.com
 
     # all slave VLANs look the same
     slave-vlan-inbound:
@@ -415,19 +395,6 @@ blobber:
         - include: universal
     outbound:
         # TODO: bug 1210137
-        - include: global-any
-
-nagios:
-    description: security group for nagios servers
-    regions:
-        us-west-1: vpc-7a7dd613
-        us-west-2: vpc-cd63f2a4
-        us-east-1: vpc-b42100df
-    inbound:
-        - include: universal
-        - include: it-admin-access
-        - include: infra-puppetize
-    outbound:
         - include: global-any
 
 # proxxy is configured per-region; these two stanzas should be kept parallel

--- a/configs/securitygroups.yml
+++ b/configs/securitygroups.yml
@@ -40,16 +40,17 @@ includes:
           - 10.22.240.0/20  # scl3-vpn-net
           - 10.22.20.0/25  # admin1.scl3-vpn
 
-    nagios-any:
-        proto: -1
+    nagios-nrpe:
+        proto: tcp
+        ports: [5666]
         hosts:
-          - nagios1.private.releng.scl3.mozilla.com  # note: includes tcp/5666
-          - nagios1.private.releng.mdc1.mozilla.com  # note: includes tcp/5666
+          - nagios1.private.releng.scl3.mozilla.com
+          - nagios1.private.releng.mdc1.mozilla.com
 
     universal:
         - include: aws-manager-ssh
         - include: jumphost-admin-access
-        - include: nagios-any
+        - include: nagios-nrpe
         - include: global-ping
 
     # infra puppetizes hosts by SSHing to them from the master
@@ -390,6 +391,8 @@ puppet-master:
             - 10.130.0.0/16
             - 10.132.0.0/16
             - 10.134.0.0/16
+            - nagios1.private.releng.scl3.mozilla.com
+            - nagios1.private.releng.mdc1.mozilla.com
 
         # Only distinguished masters need inbound ssh from other masters
 
@@ -445,6 +448,8 @@ proxxy-vpc-use1:
             - {include: test5-use1}
             - {include: try-use1}
             - {include: try2-use1}
+            - nagios1.private.releng.scl3.mozilla.com
+            - nagios1.private.releng.mdc1.mozilla.com
         - include: universal
     outbound:
         # TODO: bug 1210137
@@ -464,6 +469,8 @@ proxxy-vpc-usw2:
             - {include: test3-usw2}
             - {include: test4-usw2}
             - {include: try-usw2}
+            - nagios1.private.releng.scl3.mozilla.com
+            - nagios1.private.releng.mdc1.mozilla.com
         - include: universal
     outbound:
         # TODO: bug 1210137
@@ -483,6 +490,8 @@ LogAggregators:
             - 10.130.0.0/16
             - 10.132.0.0/16
             - 10.134.0.0/16
+            - nagios1.private.releng.scl3.mozilla.com
+            - nagios1.private.releng.mdc1.mozilla.com
         - include: universal
     outbound:
         # TODO: bug 1210137


### PR DESCRIPTION
(Collaborative effort of @davehouse and @dividehex) 

This PR is part of an overall Q3 OKR to implement host-based fire-walling with the ultimate intent to limit administrative access (ssh, rdp, vnc) to jumphost duo auth'ed traffic only.   Below is a bullet point summary of things:

- Remove Observium.  AFIAK, this is not used by netops any longer and shouldn't be allowed to touch snmp on the ec2 hosts.  We also shouldn't be running snmp on any ec2 hosts.  I've checked with #moc and they show no record of needing it since the monitor that on the scl3 net equipment already.  HT to @hwine and @fauweh for info on this.

- Refined admin access: currently, admin access allows ANY protocol on ANY port from a wide range of admin hosts, nagios, vpn ip, etc.  This removes all of that and replaces it with a much more narrow access definition of 'TCP/ssh,rdp,vnc' from only jumphosts, corp jumphosts and vpn user ips.  In a later PR, we will remove corp jumphost and vpn user ips in order to force all through the releng duo auth jumphosts (aka rejh).

- Remove puppetmaster ssh inbound.  All puppet masters make outgoing connections (git push/pull and rsync cron jobs) to the distinguished puppetmaster in scl3.  Therefore only the distinguished master needs inbound exceptions for ssh.  So we remove the ssh inbound for AWS puppetmasters from OTHER masters.

- Explicitly limit nagios.  Nagios is included in the admin-access and therefore has access to ANY protocol and ANY port.  We definitely don't want this!  So this limits nagios to only access nrpe (port 5666) and we make explicit additions to certain ports nagios is monitoring directly (eg http/s checks, cert expiration checks, etc)

- Finally we remove the nagios security group and any exclusively used includes along with it.  AFAIK, there is no longer any IT managed nagios hosts in releng AWS.  Therefore, we rip it out.
