### PR TITLE
Bug 1444467: update instance data files with mdc1/mdc2 puppetmasters

### DIFF
--- a/instance_data/instance_data_generic.json
+++ b/instance_data/instance_data_generic.json
@@ -1,4 +1,4 @@
 {
-  "dev_puppet_masters": ["releng-puppet2.srv.releng.scl3.mozilla.com"],
-  "puppet_masters": ["releng-puppet1.srv.releng.scl3.mozilla.com", "releng-puppet2.srv.releng.scl3.mozilla.com", "releng-puppet1.srv.releng.use1.mozilla.com", "releng-puppet1.srv.releng.usw2.mozilla.com"]
+  "dev_puppet_masters": ["releng-puppet2.srv.releng.mdc1.mozilla.com"],
+  "puppet_masters": ["releng-puppet1.srv.releng.mdc1.mozilla.com", "releng-puppet2.srv.releng.mdc1.mozilla.com", "releng-puppet1.srv.releng.mdc2.mozilla.com", "releng-puppet2.srv.releng.mdc2.mozilla.com", "releng-puppet1.srv.releng.use1.mozilla.com", "releng-puppet1.srv.releng.usw2.mozilla.com"]
 }

--- a/instance_data/us-east-1.instance_data_dev.json
+++ b/instance_data/us-east-1.instance_data_dev.json
@@ -1,6 +1,6 @@
 {
   "buildslave_password": "pass",
   "buildbot_master": "10.12.48.14:1313",
-  "dev_puppet_masters": ["releng-puppet2.srv.releng.scl3.mozilla.com"],
-  "puppet_masters": ["releng-puppet1.srv.releng.scl3.mozilla.com", "releng-puppet2.srv.releng.scl3.mozilla.com", "releng-puppet1.srv.releng.use1.mozilla.com", "releng-puppet1.srv.releng.usw2.mozilla.com"]
+  "dev_puppet_masters": ["releng-puppet2.srv.releng.mdc1.mozilla.com"],
+  "puppet_masters": ["releng-puppet1.srv.releng.mdc1.mozilla.com", "releng-puppet2.srv.releng.mdc1.mozilla.com", "releng-puppet1.srv.releng.mdc2.mozilla.com", "releng-puppet2.srv.releng.mdc2.mozilla.com", "releng-puppet1.srv.releng.use1.mozilla.com", "releng-puppet1.srv.releng.usw2.mozilla.com"]
 }

--- a/instance_data/us-east-1.instance_data_master.json
+++ b/instance_data/us-east-1.instance_data_master.json
@@ -1,4 +1,4 @@
 {
-  "dev_puppet_masters": ["releng-puppet2.srv.releng.scl3.mozilla.com"],
-  "puppet_masters": ["releng-puppet1.srv.releng.scl3.mozilla.com", "releng-puppet2.srv.releng.scl3.mozilla.com", "releng-puppet1.srv.releng.use1.mozilla.com", "releng-puppet1.srv.releng.usw2.mozilla.com"]
+  "dev_puppet_masters": ["releng-puppet2.srv.releng.mdc1.mozilla.com"],
+  "puppet_masters": ["releng-puppet1.srv.releng.mdc1.mozilla.com", "releng-puppet2.srv.releng.mdc1.mozilla.com", "releng-puppet1.srv.releng.mdc2.mozilla.com", "releng-puppet2.srv.releng.mdc2.mozilla.com", "releng-puppet1.srv.releng.use1.mozilla.com", "releng-puppet1.srv.releng.usw2.mozilla.com"]
 }

--- a/instance_data/us-east-1.instance_data_prod.json
+++ b/instance_data/us-east-1.instance_data_prod.json
@@ -1,4 +1,4 @@
 {
-  "dev_puppet_masters": ["releng-puppet2.srv.releng.scl3.mozilla.com"],
-  "puppet_masters": ["releng-puppet1.srv.releng.scl3.mozilla.com", "releng-puppet2.srv.releng.scl3.mozilla.com", "releng-puppet1.srv.releng.use1.mozilla.com", "releng-puppet1.srv.releng.usw2.mozilla.com"]
+  "dev_puppet_masters": ["releng-puppet2.srv.releng.mdc1.mozilla.com"],
+  "puppet_masters": ["releng-puppet1.srv.releng.mdc1.mozilla.com", "releng-puppet2.srv.releng.mdc1.mozilla.com", "releng-puppet1.srv.releng.mdc2.mozilla.com", "releng-puppet2.srv.releng.mdc2.mozilla.com", "releng-puppet1.srv.releng.use1.mozilla.com", "releng-puppet1.srv.releng.usw2.mozilla.com"]
 }

--- a/instance_data/us-east-1.instance_data_server_linux64.json
+++ b/instance_data/us-east-1.instance_data_server_linux64.json
@@ -1,4 +1,4 @@
 {
-  "dev_puppet_masters": ["releng-puppet2.srv.releng.scl3.mozilla.com"],
-  "puppet_masters": ["releng-puppet1.srv.releng.scl3.mozilla.com", "releng-puppet2.srv.releng.scl3.mozilla.com", "releng-puppet1.srv.releng.use1.mozilla.com", "releng-puppet1.srv.releng.usw2.mozilla.com"]
+  "dev_puppet_masters": ["releng-puppet2.srv.releng.mdc1.mozilla.com"],
+  "puppet_masters": ["releng-puppet1.srv.releng.mdc1.mozilla.com", "releng-puppet2.srv.releng.mdc1.mozilla.com", "releng-puppet1.srv.releng.mdc2.mozilla.com", "releng-puppet2.srv.releng.mdc2.mozilla.com", "releng-puppet1.srv.releng.use1.mozilla.com", "releng-puppet1.srv.releng.usw2.mozilla.com"]
 }

--- a/instance_data/us-east-1.instance_data_tests.json
+++ b/instance_data/us-east-1.instance_data_tests.json
@@ -1,4 +1,4 @@
 {
-  "dev_puppet_masters": ["releng-puppet2.srv.releng.scl3.mozilla.com"],
-  "puppet_masters": ["releng-puppet1.srv.releng.scl3.mozilla.com", "releng-puppet2.srv.releng.scl3.mozilla.com", "releng-puppet1.srv.releng.use1.mozilla.com", "releng-puppet1.srv.releng.usw2.mozilla.com"]
+  "dev_puppet_masters": ["releng-puppet2.srv.releng.mdc1.mozilla.com"],
+  "puppet_masters": ["releng-puppet1.srv.releng.mdc1.mozilla.com", "releng-puppet2.srv.releng.mdc1.mozilla.com", "releng-puppet1.srv.releng.mdc2.mozilla.com", "releng-puppet2.srv.releng.mdc2.mozilla.com", "releng-puppet1.srv.releng.use1.mozilla.com", "releng-puppet1.srv.releng.usw2.mozilla.com"]
 }

--- a/instance_data/us-east-1.instance_data_try.json
+++ b/instance_data/us-east-1.instance_data_try.json
@@ -1,4 +1,4 @@
 {
-  "dev_puppet_masters": ["releng-puppet2.srv.releng.scl3.mozilla.com"],
-  "puppet_masters": ["releng-puppet1.srv.releng.scl3.mozilla.com", "releng-puppet2.srv.releng.scl3.mozilla.com", "releng-puppet1.srv.releng.use1.mozilla.com", "releng-puppet1.srv.releng.usw2.mozilla.com"]
+  "dev_puppet_masters": ["releng-puppet2.srv.releng.mdc1.mozilla.com"],
+  "puppet_masters": ["releng-puppet1.srv.releng.mdc1.mozilla.com", "releng-puppet2.srv.releng.mdc1.mozilla.com", "releng-puppet1.srv.releng.mdc2.mozilla.com", "releng-puppet2.srv.releng.mdc2.mozilla.com", "releng-puppet1.srv.releng.use1.mozilla.com", "releng-puppet1.srv.releng.usw2.mozilla.com"]
 }

--- a/instance_data/us-west-1.instance_data_server_linux64.json
+++ b/instance_data/us-west-1.instance_data_server_linux64.json
@@ -1,3 +1,3 @@
 {
-  "puppet_masters": ["releng-puppet1.srv.releng.scl3.mozilla.com", "releng-puppet2.srv.releng.scl3.mozilla.com", "releng-puppet1.srv.releng.use1.mozilla.com", "releng-puppet1.srv.releng.usw2.mozilla.com"]
+  "puppet_masters": ["releng-puppet1.srv.releng.mdc1.mozilla.com", "releng-puppet2.srv.releng.mdc1.mozilla.com", "releng-puppet1.srv.releng.mdc2.mozilla.com", "releng-puppet2.srv.releng.mdc2.mozilla.com", "releng-puppet1.srv.releng.use1.mozilla.com", "releng-puppet1.srv.releng.usw2.mozilla.com"]
 }

--- a/instance_data/us-west-2.instance_data_server_linux64.json
+++ b/instance_data/us-west-2.instance_data_server_linux64.json
@@ -1,3 +1,3 @@
 {
-  "puppet_masters": ["releng-puppet1.srv.releng.scl3.mozilla.com", "releng-puppet2.srv.releng.scl3.mozilla.com", "releng-puppet1.srv.releng.use1.mozilla.com", "releng-puppet1.srv.releng.usw2.mozilla.com"]
+  "puppet_masters": ["releng-puppet1.srv.releng.mdc1.mozilla.com", "releng-puppet2.srv.releng.mdc1.mozilla.com", "releng-puppet1.srv.releng.mdc2.mozilla.com", "releng-puppet2.srv.releng.mdc2.mozilla.com", "releng-puppet1.srv.releng.use1.mozilla.com", "releng-puppet1.srv.releng.usw2.mozilla.com"]
 }


### PR DESCRIPTION
        This commit updates all the instance data files to include mdc1
        and mdc2 puppetmasters while removing the scl3 puppetmasters.
        The scl3 puppetmasters will die soon along with scl3 itself.
        This also changes the dev puppet master to point the
        releng-puppet2.srv.releng.mdc1 which means users will need to
        begin using that host for their puppet dev environments.  That
        host will also be promoted to the distinguised puppetmaster very
        soon.