### PR TITLE
Bump pyyaml version.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     install_requires=[
         'Fabric==1.8.0',
         'MySQL-python==1.2.5',
-        'PyYAML==3.11',
+        'PyYAML==3.12',
         'SQLAlchemy==0.8.3',
         'argparse>=1.2.1',
         'boto==2.27.0',


### PR DESCRIPTION
Over in https://bugzilla.mozilla.org/show_bug.cgi?id=1450035 we bumped the pyyaml version on aws_manager (to match what was available on the Puppet servers). It looks like cloud tools and puppet are fighting a battle over which version to keep installed -- let's update this one to match what's in Puppet.