### PR TITLE
stop triggering linux esr52 builds for thunderbird

### DIFF
--- a/configs/watch_pending.cfg
+++ b/configs/watch_pending.cfg
@@ -13,6 +13,7 @@
         "^release-.*_tag_(source|l10n)": "bld-linux64",
         "^release-.*_(updates|bncr_sub|chcksms|schedule_publishing_in_balrog|postrelease)": "bld-linux64",
         "^release-.*_(uptake_monitoring|publish_balrog|bouncer_aliases|mark_as_shipped|version_bump)": "bld-linux64",
+        "^release-.*-update_shipping_.*": "bld-linux64",
         "Android.* (?!try|Tegra|Panda|Emulator|debug)\\S+ (?:debug )?(build|non-unified)": "bld-linux64",
         "Android.* (?!Tegra|Panda|Emulator)try (?:debug )?build": "try-linux64",
         "^(TB )?Linux (Code Coverage |Mulet )?(?!try)\\S+ (pgo-|leak test |Code Coverage |Mulet )?(spidermonkey.* )?build": "bld-linux64",


### PR DESCRIPTION
(releaseduty triggers esr52 linux builds to unblock thunderbird releases)