### PR TITLE
Add moz.tools and code coverage backend DNS

### DIFF
--- a/terraform/base/route53.tf
+++ b/terraform/base/route53.tf
@@ -5,6 +5,11 @@ resource "aws_route53_zone" "mozilla-releng" {
     name = "mozilla-releng.net."
 }
 
+# Hosted Zone for moz.tools
+resource "aws_route53_zone" "moztools" {
+    name = "moz.tools"
+}
+
 ##################################
 ## Heroku production app cnames ##
 ##################################
@@ -52,6 +57,18 @@ resource "aws_route53_record" "heroku-treestatus-cname-prod" {
     records = ["treestatus.mozilla-releng.net.herokudns.com"]
 }
 
+############################################
+## Heroku moz.tools production app cnames ##
+############################################
+
+resource "aws_route53_record" "heroku-coverage-cname-prod" {
+    zone_id = "${aws_route53_zone.moztools.zone_id}"
+    name = "coverage.moz.tools"
+    type = "CNAME"
+    ttl = "180"
+    records = ["coverage.moz.tools.herokudns.com"]
+}
+
 
 ###############################
 ## Heroku staging app cnames ##
@@ -93,6 +110,17 @@ resource "aws_route53_record" "heroku-tooltool-cname-stage" {
     records = ["shizuoka-60622.herokussl.com"]
 }
 
+#########################################
+## Heroku moz.tools staging app cnames ##
+#########################################
+
+resource "aws_route53_record" "heroku-coverage-cname-stage" {
+    zone_id = "${aws_route53_zone.moztools.zone_id}"
+    name = "coverage.staging.moz.tools"
+    type = "CNAME"
+    ttl = "180"
+    records = ["coverage.staging.moz.tools.herokudns.com"]
+}
 
 #########################################
 ## Heroku Shipit production app cnames ##
@@ -189,6 +217,18 @@ resource "aws_route53_record" "heroku-workflow-ui-shipit-cname-stage" {
     type = "CNAME"
     ttl = "180"
     records = ["shipit-ui-workflow.staging.mozilla-releng.net.herokudns.com"]
+}
+
+#########################################
+## Heroku moz.tools testing app cnames ##
+#########################################
+
+resource "aws_route53_record" "heroku-coverage-cname-test" {
+    zone_id = "${aws_route53_zone.moztools.zone_id}"
+    name = "coverage.testing.moz.tools"
+    type = "CNAME"
+    ttl = "180"
+    records = ["coverage.testing.moz.tools.herokudns.com"]
 }
 
 ############################


### PR DESCRIPTION
I'm working for Release Management, building a new code coverage service on [mozilla-releng/services](https://github.com/mozilla-releng/services/) with @marco-c.

We got a new domain name **moz.tools** registered, and would like to use its subdomains for our 3  Heroku instances :

* `coverage.moz.tools`
* `coverage.staging.moz.tools`
* `coverage.testing.moz.tools` 

Could you also give me the Route53 server used to finish the DNS setup. Thanks !

Ping @dividehex, as specified on the [documentation](https://docs.mozilla-releng.net/deploy/configure-dns.html) 