### PR TITLE
Bug 1480861: Setup new VPNs between AWS and MDC1/2

### DIFF
--- a/terraform/vpns/backend.tf
+++ b/terraform/vpns/backend.tf
@@ -1,0 +1,10 @@
+# As of 0.9.0, remote state is configured through the new backend system
+# See https://www.terraform.io/docs/backends/legacy-0-8.html
+
+terraform {
+  backend "s3" {
+    bucket = "tf-base"
+    key    = "tf_state/vpns/terraform.tfstate"
+    region = "us-east-1"
+  }
+}

--- a/terraform/vpns/initialize.tf
+++ b/terraform/vpns/initialize.tf
@@ -1,0 +1,1 @@
+../initialize.tf

--- a/terraform/vpns/provider.tf
+++ b/terraform/vpns/provider.tf
@@ -1,0 +1,20 @@
+provider "aws" {
+    region = "${var.region}"
+    profile = "${var.profile}"
+}
+provider "aws" {
+    alias = "us-east-1"
+    region = "us-east-1"
+    profile = "${var.profile}"
+}
+provider "aws" {
+    alias = "us-west-1"
+    region = "us-west-1"
+    profile = "${var.profile}"
+}
+provider "aws" {
+    alias = "us-west-2"
+    region = "us-west-2"
+    profile = "${var.profile}"
+}
+

--- a/terraform/vpns/resources.tf
+++ b/terraform/vpns/resources.tf
@@ -1,0 +1,1 @@
+../resources.tf

--- a/terraform/vpns/terraform.tfvars
+++ b/terraform/vpns/terraform.tfvars
@@ -1,0 +1,3 @@
+profile="mozilla-releng"
+env="vpns"
+region="us-east-1"

--- a/terraform/vpns/use1.tf
+++ b/terraform/vpns/use1.tf
@@ -1,0 +1,63 @@
+resource "aws_vpn_gateway" "vpn_gw_use1" {
+  provider = "aws.us-east-1"
+
+  tags {
+    Name = "USE1 VPN Gateway"
+    terraform_managed = "True"
+    repo_url = "https://github.com/mozilla-releng/build-cloud-tools"
+  }
+}
+
+resource "aws_customer_gateway" "cgw_use1_mdc1" {
+  provider = "aws.us-east-1"
+  bgp_asn    = 65048
+  ip_address = "63.245.208.251"
+  type       = "ipsec.1"
+
+  tags {
+    Name = "MDC1 Customer Gateway"
+    terraform_managed = "True"
+    repo_url = "https://github.com/mozilla-releng/build-cloud-tools"
+  }
+
+}
+resource "aws_customer_gateway" "cgw_use1_mdc2" {
+  provider = "aws.us-east-1"
+  bgp_asn    = 65050
+  ip_address = "63.245.210.251"
+  type       = "ipsec.1"
+
+  tags {
+    Name = "MDC2 Customer Gateway"
+    terraform_managed = "True"
+    repo_url = "https://github.com/mozilla-releng/build-cloud-tools"
+  }
+
+}
+
+resource "aws_vpn_connection" "vpn_connection_use1_mdc1" {
+  provider = "aws.us-east-1"
+  vpn_gateway_id      = "${aws_vpn_gateway.vpn_gw_use1.id}"
+  customer_gateway_id = "${aws_customer_gateway.cgw_use1_mdc1.id}"
+  type                = "ipsec.1"
+
+  tags {
+    Name = "USE1-MDC1"
+    terraform_managed = "True"
+    repo_url = "https://github.com/mozilla-releng/build-cloud-tools"
+  }
+}
+
+resource "aws_vpn_connection" "vpn_connection_use1_mdc2" {
+  provider = "aws.us-east-1"
+  vpn_gateway_id      = "${aws_vpn_gateway.vpn_gw_use1.id}"
+  customer_gateway_id = "${aws_customer_gateway.cgw_use1_mdc2.id}"
+  type                = "ipsec.1"
+
+  tags {
+    Name = "USE1-MDC2"
+    terraform_managed = "True"
+    repo_url = "https://github.com/mozilla-releng/build-cloud-tools"
+  }
+}
+

--- a/terraform/vpns/usw1.tf
+++ b/terraform/vpns/usw1.tf
@@ -1,0 +1,63 @@
+resource "aws_vpn_gateway" "vpn_gw_usw1" {
+  provider = "aws.us-west-1"
+
+  tags {
+    Name = "USW1 VPN Gateway"
+    terraform_managed = "True"
+    repo_url = "https://github.com/mozilla-releng/build-cloud-tools"
+  }
+}
+
+resource "aws_customer_gateway" "cgw_usw1_mdc1" {
+  provider = "aws.us-west-1"
+  bgp_asn    = 65048
+  ip_address = "63.245.208.251"
+  type       = "ipsec.1"
+
+  tags {
+    Name = "MDC1 Customer Gateway"
+    terraform_managed = "True"
+    repo_url = "https://github.com/mozilla-releng/build-cloud-tools"
+  }
+
+}
+resource "aws_customer_gateway" "cgw_usw1_mdc2" {
+  provider = "aws.us-west-1"
+  bgp_asn    = 65050
+  ip_address = "63.245.210.251"
+  type       = "ipsec.1"
+
+  tags {
+    Name = "MDC2 Customer Gateway"
+    terraform_managed = "True"
+    repo_url = "https://github.com/mozilla-releng/build-cloud-tools"
+  }
+
+}
+
+resource "aws_vpn_connection" "vpn_connection_usw1_mdc1" {
+  provider = "aws.us-west-1"
+  vpn_gateway_id      = "${aws_vpn_gateway.vpn_gw_usw1.id}"
+  customer_gateway_id = "${aws_customer_gateway.cgw_usw1_mdc1.id}"
+  type                = "ipsec.1"
+
+  tags {
+    Name = "USW1-MDC1"
+    terraform_managed = "True"
+    repo_url = "https://github.com/mozilla-releng/build-cloud-tools"
+  }
+}
+
+resource "aws_vpn_connection" "vpn_connection_usw1_mdc2" {
+  provider = "aws.us-west-1"
+  vpn_gateway_id      = "${aws_vpn_gateway.vpn_gw_usw1.id}"
+  customer_gateway_id = "${aws_customer_gateway.cgw_usw1_mdc2.id}"
+  type                = "ipsec.1"
+
+  tags {
+    Name = "USW1-MDC2"
+    terraform_managed = "True"
+    repo_url = "https://github.com/mozilla-releng/build-cloud-tools"
+  }
+}
+

--- a/terraform/vpns/usw2.tf
+++ b/terraform/vpns/usw2.tf
@@ -1,0 +1,63 @@
+resource "aws_vpn_gateway" "vpn_gw_usw2" {
+  provider = "aws.us-west-2"
+
+  tags {
+    Name = "USW1 VPN Gateway"
+    terraform_managed = "True"
+    repo_url = "https://github.com/mozilla-releng/build-cloud-tools"
+  }
+}
+
+resource "aws_customer_gateway" "cgw_usw2_mdc1" {
+  provider = "aws.us-west-2"
+  bgp_asn    = 65048
+  ip_address = "63.245.208.251"
+  type       = "ipsec.1"
+
+  tags {
+    Name = "MDC1 Customer Gateway"
+    terraform_managed = "True"
+    repo_url = "https://github.com/mozilla-releng/build-cloud-tools"
+  }
+
+}
+resource "aws_customer_gateway" "cgw_usw2_mdc2" {
+  provider = "aws.us-west-2"
+  bgp_asn    = 65050
+  ip_address = "63.245.210.251"
+  type       = "ipsec.1"
+
+  tags {
+    Name = "MDC2 Customer Gateway"
+    terraform_managed = "True"
+    repo_url = "https://github.com/mozilla-releng/build-cloud-tools"
+  }
+
+}
+
+resource "aws_vpn_connection" "vpn_connection_usw2_mdc1" {
+  provider = "aws.us-west-2"
+  vpn_gateway_id      = "${aws_vpn_gateway.vpn_gw_usw2.id}"
+  customer_gateway_id = "${aws_customer_gateway.cgw_usw2_mdc1.id}"
+  type                = "ipsec.1"
+
+  tags {
+    Name = "USW2-MDC1"
+    terraform_managed = "True"
+    repo_url = "https://github.com/mozilla-releng/build-cloud-tools"
+  }
+}
+
+resource "aws_vpn_connection" "vpn_connection_usw2_mdc2" {
+  provider = "aws.us-west-2"
+  vpn_gateway_id      = "${aws_vpn_gateway.vpn_gw_usw2.id}"
+  customer_gateway_id = "${aws_customer_gateway.cgw_usw2_mdc2.id}"
+  type                = "ipsec.1"
+
+  tags {
+    Name = "USW2-MDC2"
+    terraform_managed = "True"
+    repo_url = "https://github.com/mozilla-releng/build-cloud-tools"
+  }
+}
+

--- a/terraform/vpns/variables.tf
+++ b/terraform/vpns/variables.tf
@@ -1,0 +1,1 @@
+../variables.tf


### PR DESCRIPTION
        This setups a new terraform config and state for managing the
        releng vpn connections between the aws regions (use1, usw2, and
        usw1) and the mozilla datacenters (mdc1 and mdc2).  This
        creates a new UNATTACHED vpn gateway, imports the existing
        mdc1/2 customer gateways and builds new connections.  It does
        not manage the current vpn gateway nor its connections.  This
        will allows us to cut over by detaching the old vpn gateway and
        attaching the new one.