### PR TITLE
fix deps for tox on travis

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ deps =
     mock
     nose
     pytest
-    pytest-cov
+    pytest-cov>=2.4.0,<2.6
 
 commands=
     flake8


### PR DESCRIPTION
travis ci is failing because of pytest-cov's req for coverage to be a higher version than we have pinned. However, it looks like args/other change for newer py-test. So let's pin to the expected version <2.6