### PR TITLE
Bug 1487798: change production treestatus cname

### DIFF
--- a/terraform/base/route53.tf
+++ b/terraform/base/route53.tf
@@ -85,7 +85,7 @@ resource "aws_route53_record" "heroku-treestatus-cname-prod" {
     name = "treestatus.mozilla-releng.net"
     type = "CNAME"
     ttl = "180"
-    records = ["kochi-31413.herokussl.com"]
+    records = ["treestatus.mozilla-releng.net.herokudns.com"]
 }
 
 ######################################


### PR DESCRIPTION
Treestatus production was moved to the heroku acm and therefore has a new ssl endpoint.