### PR TITLE
Bug 1487798: change production tooltool cname

### DIFF
--- a/terraform/base/route53.tf
+++ b/terraform/base/route53.tf
@@ -77,7 +77,7 @@ resource "aws_route53_record" "heroku-tooltool-cname-prod" {
     name = "tooltool.mozilla-releng.net"
     type = "CNAME"
     ttl = "180"
-    records = ["kochi-11433.herokussl.com"]
+    records = ["tooltool.mozilla-releng.net.herokudns.com"]
 }
 
 resource "aws_route53_record" "heroku-treestatus-cname-prod" {


### PR DESCRIPTION
Tooltool endpoint ssl has been changed to heroku's ACM.  Cname is now changed to point there.