### PR TITLE
Change coalesce cnames

### DIFF
--- a/terraform/base/route53.tf
+++ b/terraform/base/route53.tf
@@ -37,7 +37,7 @@ resource "aws_route53_record" "heroku-coalease-cname" {
     name = "coalesce.mozilla-releng.net"
     type = "CNAME"
     ttl = "180"
-    records = ["oita-54541.herokussl.com"]
+    records = ["coalesce.mozilla-releng.net.herokudns.com"]
 }
 
 resource "aws_route53_record" "heroku-mapper-cname-prod" {

--- a/terraform/base/route53.tf
+++ b/terraform/base/route53.tf
@@ -92,6 +92,14 @@ resource "aws_route53_record" "heroku-treestatus-cname-prod" {
 ## Heroku releng staging app cnames ##
 ######################################
 
+resource "aws_route53_record" "heroku-coalease-cname-stage" {
+    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
+    name = "coalesce.staging.mozilla-releng.net"
+    type = "CNAME"
+    ttl = "180"
+    records = ["coalesce.staging.mozilla-releng.net.herokudns.com"]
+}
+
 resource "aws_route53_record" "heroku-mapper-cname-stage" {
     zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
     name = "mapper.staging.mozilla-releng.net"


### PR DESCRIPTION
This changes the cname of the production coalesce application ssl enpoint now that the app is configured to use Heroku's ACM.  It also adds a cname for the coalesce staging app which didn't exist for some reason.