### PR TITLE
Add CNAME for buildhub.moz.tools

### DIFF
--- a/terraform/base/route53.tf
+++ b/terraform/base/route53.tf
@@ -28,6 +28,14 @@ resource "aws_route53_record" "relman-clouseau-moz-tools-cname-prod" {
   records = ["clouseau.moz.tools.herokudns.com"]
 }
 
+resource "aws_route53_record" "relman-buildhub-moz-tools-cname-prod" {
+  zone_id = "${aws_route53_zone.moztools.zone_id}"
+  name = "buildhub.moz.tools"
+  type = "CNAME"
+  ttl = "180"
+  records = ["prod.buildhub2.prod.cloudops.mozgcp.net"]
+}
+
 ################################
 ##  mozilla-releng.net cnames ##
 ################################


### PR DESCRIPTION
As requested on [Bugzilla](https://bugzilla.mozilla.org/show_bug.cgi?id=1505154#c5)

@garbas @dividehex How can i get an ssl certificate for this domain without using let's encrypt ?