### PR TITLE
Add root . to moztools hosted zone name

### DIFF
--- a/terraform/base/route53.tf
+++ b/terraform/base/route53.tf
@@ -5,7 +5,7 @@ resource "aws_route53_zone" "mozilla-releng" {
 }
 
 resource "aws_route53_zone" "moztools" {
-    name = "moz.tools"
+    name = "moz.tools."
 }
 
 #############################


### PR DESCRIPTION
There should have always been a '.' in the moztools hosted zone name but I think terraform is now either not adding.  Therefore without it, terraform wants to deletet the zone and recreate it.