### PR TITLE
Revert "terraform: tooltool and treestatus move production to gcp (#385)"

### DIFF
--- a/terraform/base/route53.tf
+++ b/terraform/base/route53.tf
@@ -354,7 +354,8 @@ resource "aws_route53_record" "heroku-treestatus-cname-prod" {
     name = "treestatus.mozilla-releng.net"
     type = "CNAME"
     ttl = "180"
-    records = ["prod.treestatus.prod.cloudops.mozgcp.net"]
+    records = ["treestatus.mozilla-releng.net.herokudns.com"]
+    # records = ["prod.treestatus.prod.cloudops.mozgcp.net"]
 }
 
 resource "aws_route53_record" "heroku-treestatus-cname-stage" {
@@ -383,7 +384,8 @@ resource "aws_route53_record" "heroku-tooltool-cname-prod" {
     name = "tooltool.mozilla-releng.net"
     type = "CNAME"
     ttl = "180"
-    records = ["prod.tooltool.prod.cloudops.mozgcp.net"]
+    records = ["tooltool.mozilla-releng.net.herokudns.com"]
+    # records = ["prod.tooltool.prod.cloudops.mozgcp.net"]
 }
 
 resource "aws_route53_record" "heroku-tooltool-cname-stage" {


### PR DESCRIPTION


This reverts commit bbd254146cd0a1a39798b077b529571c9a077233.