### PR TITLE
Unify code-review domain names

### DIFF
--- a/terraform/base/route53.tf
+++ b/terraform/base/route53.tf
@@ -85,10 +85,12 @@ resource "aws_route53_record" "heroku-code-coverage-backend-shipit-cname-test" {
     records = ["quiet-elk-4brvoeg6xv0mahvfwgtnveu6.herokudns.com"]
 }
 
-####################
-## Event listener ##
-####################
+#################
+## Code review ##
+#################
 
+
+# TODO: remove once switch to code-review.moz.tools is complete
 resource "aws_route53_record" "heroku-event-listener-cname-prod" {
     zone_id = "${aws_route53_zone.moztools.zone_id}"
     name = "eventlistener.moz.tools"
@@ -97,20 +99,45 @@ resource "aws_route53_record" "heroku-event-listener-cname-prod" {
     records = ["convex-woodland-ilwk96s11s92e5otfkmb5ybe.herokudns.com"]
 }
 
-resource "aws_route53_record" "heroku-event-listener-cname-stage" {
-    zone_id = "${aws_route53_zone.moztools.zone_id}"
-    name = "eventlistener.staging.moz.tools"
-    type = "CNAME"
-    ttl = "180"
-    records = ["immense-refuge-f4ii4ur88iq0x707ybzq5mfn.herokudns.com"]
-}
-
+# TODO: remove once switch to code-review.testing.moz.tools is complete
 resource "aws_route53_record" "heroku-event-listener-cname-test" {
     zone_id = "${aws_route53_zone.moztools.zone_id}"
     name = "eventlistener.testing.moz.tools"
     type = "CNAME"
     ttl = "180"
     records = ["adjacent-shelf-2mxct7inb0tl5tg1rwt73ev4.herokudns.com"]
+}
+
+resource "aws_route53_record" "heroku-event-code-review-cname-prod" {
+    zone_id = "${aws_route53_zone.moztools.zone_id}"
+    name = "events.code-review.moz.tools"
+    type = "CNAME"
+    ttl = "180"
+    records = ["computational-tulip-1uri1v0f5lt15a7auezt7p5o.herokudns.com"]
+}
+
+resource "aws_route53_record" "heroku-event-code-review-cname-test" {
+    zone_id = "${aws_route53_zone.moztools.zone_id}"
+    name = "events.code-review.testing.moz.tools"
+    type = "CNAME"
+    ttl = "180"
+    records = ["convex-raven-uc9qj36u74ermlf6qiz8fgsc.herokudns.com"]
+}
+
+resource "aws_route53_record" "heroku-backend-code-review-cname-prod" {
+    zone_id = "${aws_route53_zone.moztools.zone_id}"
+    name = "api.code-review.moz.tools"
+    type = "CNAME"
+    ttl = "180"
+    records = ["mysterious-mullberry-o1x86tkb7po3dvawe5tm1yxf.herokudns.com"]
+}
+
+resource "aws_route53_record" "heroku-backend-code-review-cname-test" {
+    zone_id = "${aws_route53_zone.moztools.zone_id}"
+    name = "api.code-review.testing.moz.tools"
+    type = "CNAME"
+    ttl = "180"
+    records = ["polar-leopard-oghlp6pg2r3w8s766swnec7j.herokudns.com"]
 }
 
 ############
@@ -356,9 +383,8 @@ variable "cloudfront_alias" {
 }
 
 variable "cloudfront_moztools_alias" {
-    default = ["static-analysis",
-               "static-analysis.staging",
-               "static-analysis.testing"]
+    default = ["code-review",
+               "code-review.testing"]
 }
 
 # Cloudfront Alias Targets
@@ -382,9 +408,8 @@ variable "cloudfront_alias_domain" {
 variable "cloudfront_moztools_alias_domain" {
     type = "map"
     default = {
-        static-analysis = "d2ezri92497z3m"
-        static-analysis.staging = "d21hzgxp28m0tc"
-        static-analysis.testing = "d1blqs705aw8h9"
+        code-review = "d2ezri92497z3m"
+        code-review.testing = "d1blqs705aw8h9"
     }
 }
 


### PR DESCRIPTION
This PR brings under the same domain `code-review.moz.tools` the 3 parts of [code-review bot](https://github.com/mozilla/code-review):

1. eventlistener.moz.tools events.code-review.moz.tools (same for testing)
2. the eventlistener.moz.tools domains are preserved until we update the Phabricator usage
3. the new code-review backend is exposed as api.code-review.moz.tools (same for testing)
4. the static-analysis frontend is directly renamed as code-review.moz.tools (same for testing)

All staging environments are not used anymore for code-review.