### PR TITLE
terraform: remove releng related dns records

### DIFF
--- a/terraform/base/route53.tf
+++ b/terraform/base/route53.tf
@@ -1,9 +1,5 @@
 # Route 53 resources
 
-resource "aws_route53_zone" "mozilla-releng" {
-    name = "mozilla-releng.net."
-}
-
 resource "aws_route53_zone" "moztools" {
     name = "moz.tools."
 }
@@ -140,269 +136,15 @@ resource "aws_route53_record" "heroku-backend-code-review-cname-test" {
     records = ["polar-leopard-oghlp6pg2r3w8s766swnec7j.herokudns.com"]
 }
 
-############
-## ShipIt ##
-############
-
-resource "aws_route53_record" "dockerflow-shipit-api-cname-prod" {
-    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
-    name= "shipit-api.mozilla-releng.net"
-    type = "CNAME"
-    ttl = "180"
-    records = ["prod.shipitapi.prod.cloudops.mozgcp.net"]
-}
-
-resource "aws_route53_record" "dockerflow-shipit-api-cname-pre" {
-  zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
-  name= "api.shipit.pre.mozilla-releng.net"
-  type = "CNAME"
-  ttl = "180"
-  records = ["stage.shipitapi.nonprod.cloudops.mozgcp.net"]
-}
-
-resource "aws_route53_record" "dockerflow-shipit-api-cname-stag" {
-  zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
-  name= "api.shipit.staging.mozilla-releng.net"
-  type = "CNAME"
-  ttl = "180"
-  records = ["dev.shipitapi.nonprod.cloudops.mozgcp.net"]
-}
-
-resource "aws_route53_record" "dockerflow-shipit-api-cname-test" {
-    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
-    name= "api.shipit.testing.mozilla-releng.net"
-    type = "CNAME"
-    ttl = "180"
-    records = ["testing.shipitapi.nonprod.cloudops.mozgcp.net"]
-}
-
-############
-## Uplift ##
-############
-
-resource "aws_route53_record" "heroku-uplift-shipit-cname-prod" {
-    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
-    name = "uplift.shipit.mozilla-releng.net"
-    type = "CNAME"
-    ttl = "180"
-    records = ["uplift.shipit.mozilla-releng.net.herokudns.com"]
-}
-
-resource "aws_route53_record" "heroku-uplift-shipit-cname-stage" {
-    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
-    name = "uplift.shipit.staging.mozilla-releng.net"
-    type = "CNAME"
-    ttl = "180"
-    records = ["uplift.shipit.staging.mozilla-releng.net.herokudns.com"]
-}
-
-resource "aws_route53_record" "heroku-uplift-shipit-cname-test" {
-    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
-    name = "uplift.shipit.testing.mozilla-releng.net"
-    type = "CNAME"
-    ttl = "180"
-    records = ["uplift.shipit.testing.mozilla-releng.net.herokudns.com"]
-}
-
-#####################
-## Product details ##
-#####################
-
-resource "aws_route53_record" "dockerflow-product-details-cname-prod" {
-    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
-    name= "product-details.mozilla-releng.net"
-    type = "CNAME"
-    ttl = "180"
-    records = ["productdetails-prod.prod.mozaws.net"]
-}
-
-resource "aws_route53_record" "dockerflow-product-details-cname-stage" {
-    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
-    name= "product-details.staging.mozilla-releng.net"
-    type = "CNAME"
-    ttl = "180"
-    records = ["productdetails-staging.stage.mozaws.net"]
-}
-
-resource "aws_route53_record" "dockerflow-product-details-cname-test" {
-    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
-    name= "product-details.testing.mozilla-releng.net"
-    type = "CNAME"
-    ttl = "180"
-    records = ["productdetails-testing.dev.mozaws.net"]
-}
-
-##############
-## Coalesce ##
-##############
-
-resource "aws_route53_record" "heroku-coalease-cname" {
-    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
-    name = "coalesce.mozilla-releng.net"
-    type = "CNAME"
-    ttl = "180"
-    records = ["coalesce.mozilla-releng.net.herokudns.com"]
-}
-
-resource "aws_route53_record" "heroku-coalease-cname-stage" {
-    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
-    name = "coalesce.staging.mozilla-releng.net"
-    type = "CNAME"
-    ttl = "180"
-    records = ["coalesce.staging.mozilla-releng.net.herokudns.com"]
-}
-
-############
-## Tokens ##
-############
-
-resource "aws_route53_record" "heroku-tokens-cname-prod" {
-    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
-    name = "tokens.mozilla-releng.net"
-    type = "CNAME"
-    ttl = "180"
-    records = ["tokens.mozilla-releng.net.herokudns.com"]
-}
-
-resource "aws_route53_record" "heroku-tokens-cname-stage" {
-    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
-    name = "tokens.staging.mozilla-releng.net"
-    type = "CNAME"
-    ttl = "180"
-    records = ["tokens.staging.mozilla-releng.net.herokudns.com"]
-}
-
-resource "aws_route53_record" "heroku-tokens-cname-test" {
-    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
-    name = "tokens.testing.mozilla-releng.net"
-    type = "CNAME"
-    ttl = "180"
-    records = ["tokens.testing.mozilla-releng.net.herokudns.com"]
-}
-
-############
-## Mapper ##
-############
-
-resource "aws_route53_record" "heroku-mapper-cname-prod" {
-    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
-    name = "mapper.mozilla-releng.net"
-    type = "CNAME"
-    ttl = "180"
-    records = ["prod.mapper.prod.cloudops.mozgcp.net"]
-}
-
-resource "aws_route53_record" "heroku-mapper-cname-stage" {
-    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
-    name = "stage.mapper.mozilla-releng.net"
-    type = "CNAME"
-    ttl = "180"
-    records = ["stage.mapper.nonprod.cloudops.mozgcp.net"]
-}
-
-resource "aws_route53_record" "heroku-mapper-cname-dev" {
-    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
-    name = "dev.mapper.mozilla-releng.net"
-    type = "CNAME"
-    ttl = "180"
-    records = ["dev.mapper.nonprod.cloudops.mozgcp.net"]
-}
-
-################
-## TreeStatus ##
-################
-
-resource "aws_route53_record" "heroku-treestatus-cname-prod" {
-    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
-    name = "treestatus.mozilla-releng.net"
-    type = "CNAME"
-    ttl = "180"
-    records = ["prod.treestatus.prod.cloudops.mozgcp.net"]
-}
-
-resource "aws_route53_record" "heroku-treestatus-cname-stage" {
-    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
-    name = "stage.treestatus.mozilla-releng.net"
-    type = "CNAME"
-    ttl = "180"
-    records = ["stage.treestatus.nonprod.cloudops.mozgcp.net"]
-}
-
-resource "aws_route53_record" "heroku-treestatus-cname-dev" {
-    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
-    name = "dev.treestatus.mozilla-releng.net"
-    type = "CNAME"
-    ttl = "180"
-    records = ["dev.treestatus.nonprod.cloudops.mozgcp.net"]
-}
-
-
-##############
-## ToolTool ##
-##############
-
-resource "aws_route53_record" "heroku-tooltool-cname-prod" {
-    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
-    name = "tooltool.mozilla-releng.net"
-    type = "CNAME"
-    ttl = "180"
-    records = ["prod.tooltool.prod.cloudops.mozgcp.net"]
-}
-
-resource "aws_route53_record" "heroku-tooltool-cname-stage" {
-    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
-    name = "stage.tooltool.mozilla-releng.net"
-    type = "CNAME"
-    ttl = "180"
-    records = ["stage.tooltool.nonprod.cloudops.mozgcp.net"]
-}
-
-resource "aws_route53_record" "heroku-tooltool-cname-dev" {
-    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
-    name = "dev.tooltool.mozilla-releng.net"
-    type = "CNAME"
-    ttl = "180"
-    records = ["dev.tooltool.nonprod.cloudops.mozgcp.net"]
-}
 
 
 ############################
 ## CloudFront CDN aliases ##
 ############################
 
-variable "cloudfront_alias" {
-    default = ["docs",
-               "docs.staging",
-               "docs.testing",
-               "shipit",
-               "shipit.staging",
-               "shipit.testing",
-               "staging",
-               "testing",
-               "www"]
-}
-
 variable "cloudfront_moztools_alias" {
     default = ["code-review",
                "code-review.testing"]
-}
-
-# Cloudfront Alias Targets
-# In the future, these may be sourced directly from terraform cloudfront resources
-# should we decide to manage cloudfronts in terraform
-variable "cloudfront_alias_domain" {
-    type = "map"
-    default = {
-        shipit = "d3phvtn087pdcs"
-        shipit.staging = "d1cttl07hxwjbl"
-        shipit.testing = "dt9vzct0e0pwk"
-        docs = "dkamdn8kujupl"
-        docs.staging = "d1cglo5i889p5y"
-        docs.testing = "d1s9qzzh9bruag"
-        www = "ddealaqd6tp6a"
-        staging = "d2qqjmci8ffy3k"
-        testing = "d1ja915kcjy2vv"
-    }
 }
 
 variable "cloudfront_moztools_alias_domain" {
@@ -410,20 +152,6 @@ variable "cloudfront_moztools_alias_domain" {
     default = {
         code-review = "d2ezri92497z3m"
         code-review.testing = "d1blqs705aw8h9"
-    }
-}
-
-# A (Alias) records for cloudfront apps
-resource "aws_route53_record" "cloudfront-alias" {
-    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
-    name = "${element(var.cloudfront_alias, count.index)}.mozilla-releng.net"
-    type = "A"
-    count = "${length(var.cloudfront_alias)}"
-
-    alias {
-        name = "${var.cloudfront_alias_domain[element(var.cloudfront_alias, count.index)]}.cloudfront.net."
-        zone_id = "Z2FDTNDATAQYW2"
-        evaluate_target_health = false
     }
 }
 
@@ -436,19 +164,6 @@ resource "aws_route53_record" "cloudfront-moztools-alias" {
     alias {
         name = "${var.cloudfront_moztools_alias_domain[element(var.cloudfront_moztools_alias, count.index)]}.cloudfront.net."
         zone_id = "Z2FDTNDATAQYW2"
-        evaluate_target_health = false
-    }
-}
-
-# A special root alias that points to www.mozilla-releng.net
-resource "aws_route53_record" "root-alias" {
-    zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
-    name = "mozilla-releng.net"
-    type = "A"
-
-    alias {
-        name = "www.mozilla-releng.net"
-        zone_id = "${aws_route53_zone.mozilla-releng.zone_id}"
         evaluate_target_health = false
     }
 }


### PR DESCRIPTION
**!!! MPORTANT !!!** This needs to be applied and merged with coordination with cloudops (cc @oremj).

The last time I tried to remove this some workers broke ([Bug 1591166](https://bugzilla.mozilla.org/show_bug.cgi?id=1591166)). Maybe dns gets cached for longer then we expect.

@La0 I also removed uplift domain. I think I asked you some time ago if this is ok, I'm 90% sure the answer was yes. can we remove this dns entries?

@rail I don't think I will be able to attend next cloudops/releng meeting and since my parental leave is coming up soon can you bring this up for a discussion and keep an eye that it we don't forget to finish it.