### PR TITLE
Revert code-review.moz.tools frontend DNS to static-analysis.moz.tools

### DIFF
--- a/terraform/base/route53.tf
+++ b/terraform/base/route53.tf
@@ -383,8 +383,9 @@ variable "cloudfront_alias" {
 }
 
 variable "cloudfront_moztools_alias" {
-    default = ["code-review",
-               "code-review.testing"]
+    default = ["static-analysis",
+               "static-analysis.staging",
+               "static-analysis.testing"]
 }
 
 # Cloudfront Alias Targets
@@ -408,8 +409,9 @@ variable "cloudfront_alias_domain" {
 variable "cloudfront_moztools_alias_domain" {
     type = "map"
     default = {
-        code-review = "d2ezri92497z3m"
-        code-review.testing = "d1blqs705aw8h9"
+        static-analysis = "d2ezri92497z3m"
+        static-analysis.staging = "d21hzgxp28m0tc"
+        static-analysis.testing = "d1blqs705aw8h9"
     }
 }
 


### PR DESCRIPTION
As I cannot update (nor releng this week) the cloudfront configuration for the code-review frontend, let's revert the DNS changes for the code-review frontend.

Could you please merge & apply these changes @dividehex ?